### PR TITLE
feat: dedicated VariantTierPrice GraphQL type; seed tier prices; add …

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prisma:generate": "CI=1 npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
     "prisma:studio": "npx prisma studio",
-    "prisma:seed": "npx ts-node prisma/seed.ts"
+    "prisma:seed": "npx ts-node prisma/seed.ts",
+    "prisma:backfillPoStoreId": "npx ts-node prisma/scripts/backfill-po-store-id.ts"
   },
   "prisma": {
     "schema": "./prisma"

--- a/prisma/migrations/20250906130044_add_storeid_to_po/migration.sql
+++ b/prisma/migrations/20250906130044_add_storeid_to_po/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "public"."PurchaseOrder" ADD COLUMN     "storeId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "public"."PurchaseOrder" ADD CONSTRAINT "PurchaseOrder_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "public"."Store"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Backfill storeId from the first receipt's store for historical data
+UPDATE "public"."PurchaseOrder" po
+SET "storeId" = sub."storeId"
+FROM (
+  SELECT "purchaseOrderId", "storeId"
+  FROM (
+    SELECT "purchaseOrderId", "storeId",
+           ROW_NUMBER() OVER (PARTITION BY "purchaseOrderId" ORDER BY "receivedAt" ASC) AS rn
+    FROM "public"."StockReceiptBatch"
+  ) t
+  WHERE rn = 1
+) sub
+WHERE po."id" = sub."purchaseOrderId" AND po."storeId" IS NULL;

--- a/prisma/modules/purchase.prisma
+++ b/prisma/modules/purchase.prisma
@@ -25,6 +25,7 @@ model Supplier {
 model PurchaseOrder {
   id              String   @id @default(uuid())
   supplierId      String
+  storeId         String?
   invoiceNumber   String
   status          PurchaseOrderStatus
   phase           PurchasePhase @default(ORDERED)
@@ -34,6 +35,7 @@ model PurchaseOrder {
   updatedAt       DateTime @updatedAt
 
   supplier        Supplier @relation(fields: [supplierId], references: [id])
+  store           Store?   @relation(fields: [storeId], references: [id])
   items           PurchaseOrderItem[]
   receipts        StockReceiptBatch[]
   payments        SupplierPayment[]

--- a/prisma/modules/stock.prisma
+++ b/prisma/modules/stock.prisma
@@ -23,6 +23,7 @@ model Store {
   Quotation Quotation[]
 
   PurchaseRequisition PurchaseRequisition[]
+  purchaseOrders      PurchaseOrder[]
 }
 
 model Stock {

--- a/prisma/scripts/backfill-po-store-id.ts
+++ b/prisma/scripts/backfill-po-store-id.ts
@@ -1,0 +1,33 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const pos = await prisma.purchaseOrder.findMany({ where: { storeId: null as any } });
+  console.log(`Found ${pos.length} purchase orders missing storeId...`);
+  let updated = 0;
+  for (const po of pos) {
+    const receipt = await prisma.stockReceiptBatch.findFirst({
+      where: { purchaseOrderId: po.id },
+      orderBy: { receivedAt: 'asc' },
+    });
+    if (receipt?.storeId) {
+      await prisma.purchaseOrder.update({
+        where: { id: po.id },
+        data: { storeId: receipt.storeId },
+      });
+      updated += 1;
+    }
+  }
+  console.log(`Backfill complete. Updated ${updated} purchase orders.`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -199,6 +199,39 @@ async function main() {
     },
   });
 
+  // Seed tier prices for the variant for testing
+  await prisma.productVariantTierPrice.upsert({
+    where: {
+      productVariantId_tier: { productVariantId: variant.id, tier: UserTier.BRONZE },
+    },
+    update: { price: 17500 },
+    create: { productVariantId: variant.id, tier: UserTier.BRONZE, price: 17500 },
+  });
+  await prisma.productVariantTierPrice.upsert({
+    where: {
+      productVariantId_tier: { productVariantId: variant.id, tier: UserTier.SILVER },
+    },
+    update: { price: 17000 },
+    create: { productVariantId: variant.id, tier: UserTier.SILVER, price: 17000 },
+  });
+  await prisma.productVariantTierPrice.upsert({
+    where: {
+      productVariantId_tier: { productVariantId: variant.id, tier: UserTier.GOLD },
+    },
+    update: { price: 16500 },
+    create: { productVariantId: variant.id, tier: UserTier.GOLD, price: 16500 },
+  });
+  await prisma.productVariantTierPrice.upsert({
+    where: {
+      productVariantId_tier: {
+        productVariantId: variant.id,
+        tier: UserTier.PLATINUM,
+      },
+    },
+    update: { price: 16000 },
+    create: { productVariantId: variant.id, tier: UserTier.PLATINUM, price: 16000 },
+  });
+
   await prisma.stock.upsert({
     where: { id: `${mainStore.id}-${variant.id}` },
     update: {},

--- a/src/modules/catalogue/types/variant-tier-price.type.ts
+++ b/src/modules/catalogue/types/variant-tier-price.type.ts
@@ -1,0 +1,15 @@
+import { ObjectType, Field, Float } from '@nestjs/graphql';
+import { UserTier } from '../../../shared/prismagraphql/prisma/user-tier.enum';
+
+@ObjectType()
+export class VariantTierPrice {
+  @Field()
+  productVariantId!: string;
+
+  @Field(() => UserTier)
+  tier!: keyof typeof UserTier;
+
+  @Field(() => Float)
+  price!: number;
+}
+

--- a/src/modules/catalogue/variant/product-variant.resolver.ts
+++ b/src/modules/catalogue/variant/product-variant.resolver.ts
@@ -21,6 +21,7 @@ import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '../../auth/guards/gql-auth.guard';
 import { UpsertVariantSupplierCatalogInput } from '../dto/upsert-variant-supplier-catalog.input';
 import { SupplierCatalogEntry } from '../../purchase/types/supplier-catalog-entry.type';
+import { VariantTierPrice } from '../types/variant-tier-price.type';
 import { UpsertVariantTierPriceInput } from '../dto/upsert-variant-tier-price.input';
 @Resolver(() => ProductVariant)
 export class ProductVariantsResolver {
@@ -122,10 +123,9 @@ export class ProductVariantsResolver {
     }).then(() => 'OK');
   }
 
-  @Query(() => [SupplierCatalogEntry])
+  @Query(() => [VariantTierPrice])
   @UseGuards(GqlAuthGuard)
   tierPricesForVariant(@Args('productVariantId') productVariantId: string) {
-    // Return as SupplierCatalogEntry-like objects for quick display
     return this.ProductVariantService.tierPricesForVariant(productVariantId);
   }
 

--- a/src/modules/purchase/purchase.service.ts
+++ b/src/modules/purchase/purchase.service.ts
@@ -153,7 +153,10 @@ export class PurchaseService {
       where: {
         dueDate: { lt: now },
         status: { in: ['PENDING', 'PARTIALLY_PAID'] as any },
-        receipts: { some: { storeId } },
+        OR: [
+          { storeId },
+          { receipts: { some: { storeId } } }, // fallback for historical POs
+        ],
       },
       include: { items: true },
       orderBy: { dueDate: 'asc' },
@@ -1218,6 +1221,7 @@ export class PurchaseService {
       const po = await this.prisma.purchaseOrder.create({
         data: {
           supplierId,
+          storeId: req.storeId,
           invoiceNumber: `PO-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
           status: 'PENDING',
           phase: 'ORDERED' as any,

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -228,6 +228,7 @@ type PurchaseOrderCount {
 type PurchaseOrder {
   id: ID!
   supplierId: String!
+  storeId: String
   invoiceNumber: String!
   status: PurchaseOrderStatus!
   phase: PurchasePhase!
@@ -236,6 +237,7 @@ type PurchaseOrder {
   createdAt: DateTime!
   updatedAt: DateTime!
   supplier: Supplier!
+  store: Store
   items: [PurchaseOrderItem!]
   receipts: [StockReceiptBatch!]
   payments: [SupplierPayment!]
@@ -884,6 +886,14 @@ type StockMovementItem {
   productVariant: ProductVariant!
 }
 
+type ProductVariantTierPrice {
+  id: ID!
+  productVariantId: String!
+  tier: UserTier!
+  price: Float!
+  variant: ProductVariant!
+}
+
 type ProductVariantCount {
   stockItems: Int!
   receiptItems: Int!
@@ -898,6 +908,7 @@ type ProductVariantCount {
   PurchaseRequisitionItem: Int!
   SupplierCatalog: Int!
   SupplierQuoteItem: Int!
+  ProductVariantTierPrice: Int!
 }
 
 type ProductVariant {
@@ -926,6 +937,7 @@ type ProductVariant {
   PurchaseRequisitionItem: [PurchaseRequisitionItem!]
   SupplierCatalog: [SupplierCatalog!]
   SupplierQuoteItem: [SupplierQuoteItem!]
+  ProductVariantTierPrice: [ProductVariantTierPrice!]
   _count: ProductVariantCount!
 }
 
@@ -956,6 +968,7 @@ type StoreCount {
   CustomerProfile: Int!
   Quotation: Int!
   PurchaseRequisition: Int!
+  purchaseOrders: Int!
 }
 
 type Store {
@@ -979,6 +992,7 @@ type Store {
   CustomerProfile: [CustomerProfile!]
   Quotation: [Quotation!]
   PurchaseRequisition: [PurchaseRequisition!]
+  purchaseOrders: [PurchaseOrder!]
   _count: StoreCount!
 }
 
@@ -1295,6 +1309,12 @@ type SupplierCatalogEntry {
   isPreferred: Boolean
 }
 
+type VariantTierPrice {
+  productVariantId: String!
+  tier: UserTier!
+  price: Float!
+}
+
 type StoreCountAggregate {
   id: Int!
   name: Int!
@@ -1399,6 +1419,7 @@ type SupplierMaxAggregate {
 type PurchaseOrderCountAggregate {
   id: Int!
   supplierId: Int!
+  storeId: Int!
   invoiceNumber: Int!
   status: Int!
   phase: Int!
@@ -1420,6 +1441,7 @@ type PurchaseOrderSumAggregate {
 type PurchaseOrderMinAggregate {
   id: String
   supplierId: String
+  storeId: String
   invoiceNumber: String
   status: PurchaseOrderStatus
   phase: PurchasePhase
@@ -1432,6 +1454,7 @@ type PurchaseOrderMinAggregate {
 type PurchaseOrderMaxAggregate {
   id: String
   supplierId: String
+  storeId: String
   invoiceNumber: String
   status: PurchaseOrderStatus
   phase: PurchasePhase
@@ -1967,6 +1990,7 @@ type Query {
   variantsByStore(storeId: String!, search: String): [ProductVariant!]!
   lowStockByStore(storeId: String!): [ProductVariant!]!
   suppliersForVariant(productVariantId: String!): [SupplierCatalogEntry!]!
+  tierPricesForVariant(productVariantId: String!): [VariantTierPrice!]!
   notifications: [Notification!]!
   suppliers: [Supplier!]!
   supplier(id: String!): Supplier!
@@ -1990,6 +2014,12 @@ type Query {
   rfqDashboard(requisitionId: String!): RfqDashboard!
   rfqDashboardAll: RfqDashboard!
   adminProcurementDashboard: AdminProcurementDashboard!
+  purchaseOrdersOverdueByStore(storeId: String!): [PurchaseOrder!]!
+  requisitionsWithNoSubmittedQuotesByStore(storeId: String!): [RequisitionSummary!]!
+  requisitionsWithPartialSubmissionsByStore(storeId: String!): [RequisitionSummary!]!
+  rfqStatusCountsByStore(storeId: String!): RfqStatusCounts!
+  rfqDashboardByStore(storeId: String!): RfqDashboard!
+  adminProcurementDashboardByStore(storeId: String!): AdminProcurementDashboard!
   stock(input: QueryStockInput): [Stock!]!
   stockMovements(storeId: String!): [StockMovement!]!
   ordersQuery: [SaleOrder!]!
@@ -2161,6 +2191,7 @@ input ProductVariantWhereInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemListRelationFilter
   SupplierCatalog: SupplierCatalogListRelationFilter
   SupplierQuoteItem: SupplierQuoteItemListRelationFilter
+  ProductVariantTierPrice: ProductVariantTierPriceListRelationFilter
 }
 
 input FloatFilter {
@@ -2286,6 +2317,7 @@ input StoreWhereInput {
   CustomerProfile: CustomerProfileListRelationFilter
   Quotation: QuotationListRelationFilter
   PurchaseRequisition: PurchaseRequisitionListRelationFilter
+  purchaseOrders: PurchaseOrderListRelationFilter
 }
 
 input BoolFilter {
@@ -3344,6 +3376,7 @@ input PurchaseOrderWhereInput {
   NOT: [PurchaseOrderWhereInput!]
   id: StringFilter
   supplierId: StringFilter
+  storeId: StringNullableFilter
   invoiceNumber: StringFilter
   status: EnumPurchaseOrderStatusFilter
   phase: EnumPurchasePhaseFilter
@@ -3352,6 +3385,7 @@ input PurchaseOrderWhereInput {
   createdAt: DateTimeFilter
   updatedAt: DateTimeFilter
   supplier: SupplierScalarRelationFilter
+  store: StoreNullableScalarRelationFilter
   items: PurchaseOrderItemListRelationFilter
   receipts: StockReceiptBatchListRelationFilter
   payments: SupplierPaymentListRelationFilter
@@ -3851,6 +3885,23 @@ input ProductSalesStatsWhereInput {
   productVariant: ProductVariantScalarRelationFilter
 }
 
+input ProductVariantTierPriceListRelationFilter {
+  every: ProductVariantTierPriceWhereInput
+  some: ProductVariantTierPriceWhereInput
+  none: ProductVariantTierPriceWhereInput
+}
+
+input ProductVariantTierPriceWhereInput {
+  AND: [ProductVariantTierPriceWhereInput!]
+  OR: [ProductVariantTierPriceWhereInput!]
+  NOT: [ProductVariantTierPriceWhereInput!]
+  id: StringFilter
+  productVariantId: StringFilter
+  tier: EnumUserTierFilter
+  price: FloatFilter
+  variant: ProductVariantScalarRelationFilter
+}
+
 input ProductOrderByWithRelationInput {
   id: SortOrder
   name: SortOrder
@@ -4189,6 +4240,7 @@ input ProductVariantOrderByWithRelationInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemOrderByRelationAggregateInput
   SupplierCatalog: SupplierCatalogOrderByRelationAggregateInput
   SupplierQuoteItem: SupplierQuoteItemOrderByRelationAggregateInput
+  ProductVariantTierPrice: ProductVariantTierPriceOrderByRelationAggregateInput
 }
 
 input StockOrderByRelationAggregateInput {
@@ -4253,6 +4305,10 @@ input SupplierQuoteItemOrderByRelationAggregateInput {
   _count: SortOrder
 }
 
+input ProductVariantTierPriceOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
 input ProductVariantWhereUniqueInput {
   id: String
   barcode: String
@@ -4282,6 +4338,7 @@ input ProductVariantWhereUniqueInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemListRelationFilter
   SupplierCatalog: SupplierCatalogListRelationFilter
   SupplierQuoteItem: SupplierQuoteItemListRelationFilter
+  ProductVariantTierPrice: ProductVariantTierPriceListRelationFilter
 }
 
 enum ProductVariantScalarFieldEnum {
@@ -4488,6 +4545,7 @@ input StoreOrderByWithRelationInput {
   CustomerProfile: CustomerProfileOrderByRelationAggregateInput
   Quotation: QuotationOrderByRelationAggregateInput
   PurchaseRequisition: PurchaseRequisitionOrderByRelationAggregateInput
+  purchaseOrders: PurchaseOrderOrderByRelationAggregateInput
 }
 
 input UserOrderByWithRelationInput {
@@ -4710,6 +4768,10 @@ input CustomerOrderByRelationAggregateInput {
   _count: SortOrder
 }
 
+input PurchaseOrderOrderByRelationAggregateInput {
+  _count: SortOrder
+}
+
 input StoreWhereUniqueInput {
   id: String
   AND: [StoreWhereInput!]
@@ -4734,6 +4796,7 @@ input StoreWhereUniqueInput {
   CustomerProfile: CustomerProfileListRelationFilter
   Quotation: QuotationListRelationFilter
   PurchaseRequisition: PurchaseRequisitionListRelationFilter
+  purchaseOrders: PurchaseOrderListRelationFilter
 }
 
 enum StoreScalarFieldEnum {
@@ -5111,6 +5174,7 @@ type Mutation {
   deleteProductVariant(where: ProductVariantWhereUniqueInput!): ProductVariant
   deleteManyProductVariant(where: ProductVariantWhereInput, limit: Int): AffectedRows
   upsertVariantSupplierCatalog(input: UpsertVariantSupplierCatalogInput!): SupplierCatalogEntry!
+  upsertVariantTierPrice(input: UpsertVariantTierPriceInput!): String!
   markAsRead(id: String!): Notification!
   signupCustomer(input: CreateUserInput!): AuthResponse!
   completeCustomerProfile(input: UpdateCustomerProfileInput!): CustomerProfile!
@@ -5240,6 +5304,7 @@ input ProductVariantCreateWithoutProductInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input StockCreateNestedManyWithoutProductVariantInput {
@@ -5285,6 +5350,7 @@ input StoreCreateWithoutStocksInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input UserCreateNestedOneWithoutStoreInput {
@@ -5522,6 +5588,7 @@ input StoreCreateWithoutCustomerProfileInput {
   Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StockCreateNestedManyWithoutStoreInput {
@@ -5572,6 +5639,7 @@ input ProductVariantCreateWithoutStockItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input ProductCreateNestedOneWithoutVariantsInput {
@@ -5651,6 +5719,7 @@ input StoreCreateWithoutReceiptsInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StockTransferCreateNestedManyWithoutFromStoreInput {
@@ -5695,6 +5764,7 @@ input StoreCreateWithoutTransfersInInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StockReceiptBatchCreateNestedManyWithoutStoreInput {
@@ -5878,6 +5948,7 @@ input StoreCreateWithoutCustomerInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StockTransferCreateNestedManyWithoutToStoreInput {
@@ -5922,6 +5993,7 @@ input StoreCreateWithoutTransfersOutInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input ConsumerSaleCreateNestedManyWithoutStoreInput {
@@ -6221,6 +6293,7 @@ input StoreCreateWithoutCustomerSalesInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input SalesReturnCreateNestedManyWithoutStoreInput {
@@ -6470,6 +6543,7 @@ input StoreCreateWithoutQuotationInput {
   Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input ResellerSaleCreateNestedManyWithoutStoreInput {
@@ -6610,6 +6684,7 @@ input ProductVariantCreateWithoutReceiptItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input QuotationItemCreateNestedManyWithoutProductVariantInput {
@@ -6796,6 +6871,7 @@ input StoreCreateWithoutManagerInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StockMovementCreateNestedManyWithoutStoreInput {
@@ -6858,6 +6934,7 @@ input ProductVariantCreateWithoutStockMovementItemInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input ResellerSaleItemCreateNestedManyWithoutProductVariantInput {
@@ -7102,6 +7179,7 @@ input ProductVariantCreateWithoutConsumerItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input SalesReturnItemCreateNestedManyWithoutProductVariantInput {
@@ -7394,6 +7472,7 @@ input StoreCreateWithoutResellerSalesInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input CustomerCreateNestedManyWithoutPreferredStoreInput {
@@ -7574,6 +7653,7 @@ input ProductVariantCreateWithoutResellerItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input ConsumerSaleItemCreateNestedManyWithoutProductVariantInput {
@@ -8059,78 +8139,252 @@ input PurchaseOrderCreateWithoutSupplierInput {
   totalAmount: Float!
   createdAt: DateTime
   updatedAt: DateTime
+  store: StoreCreateNestedOneWithoutPurchaseOrdersInput
   items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
   receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
   payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
 }
 
-input PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput {
-  create: [PurchaseOrderItemCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput!]
-  createMany: PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope
-  connect: [PurchaseOrderItemWhereUniqueInput!]
+input StoreCreateNestedOneWithoutPurchaseOrdersInput {
+  create: StoreCreateWithoutPurchaseOrdersInput
+  connectOrCreate: StoreCreateOrConnectWithoutPurchaseOrdersInput
+  connect: StoreWhereUniqueInput
 }
 
-input PurchaseOrderItemCreateWithoutPurchaseOrderInput {
+input StoreCreateWithoutPurchaseOrdersInput {
   id: String
-  quantity: Int!
-  unitCost: Float!
-  productVariant: ProductVariantCreateNestedOneWithoutPurchaseOrderItemInput!
-}
-
-input ProductVariantCreateNestedOneWithoutPurchaseOrderItemInput {
-  create: ProductVariantCreateWithoutPurchaseOrderItemInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput
-  connect: ProductVariantWhereUniqueInput
-}
-
-input ProductVariantCreateWithoutPurchaseOrderItemInput {
-  id: String
-  size: String!
-  concentration: String!
-  packaging: String!
-  barcode: String
-  price: Float!
-  resellerPrice: Float!
+  name: String!
+  location: String
+  isMain: Boolean
   createdAt: DateTime
   updatedAt: DateTime
-  product: ProductCreateNestedOneWithoutVariantsInput!
-  stockItems: StockCreateNestedManyWithoutProductVariantInput
-  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
-  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
-  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
-  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
-  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
-  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
-  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
-  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
-  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
-  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
-  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  manager: UserCreateNestedOneWithoutStoreInput!
+  stocks: StockCreateNestedManyWithoutStoreInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutStoreInput
+  transfersOut: StockTransferCreateNestedManyWithoutFromStoreInput
+  transfersIn: StockTransferCreateNestedManyWithoutToStoreInput
+  customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
+  salesReturns: SalesReturnCreateNestedManyWithoutStoreInput
+  resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
+  movements: StockMovementCreateNestedManyWithoutStoreInput
+  Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
+  CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
+  Quotation: QuotationCreateNestedManyWithoutStoreInput
+  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
 }
 
-input PurchaseReturnItemCreateNestedManyWithoutProductVariantInput {
-  create: [PurchaseReturnItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: PurchaseReturnItemCreateManyProductVariantInputEnvelope
-  connect: [PurchaseReturnItemWhereUniqueInput!]
+input CustomerProfileCreateNestedManyWithoutPreferredStoreInput {
+  create: [CustomerProfileCreateWithoutPreferredStoreInput!]
+  connectOrCreate: [CustomerProfileCreateOrConnectWithoutPreferredStoreInput!]
+  createMany: CustomerProfileCreateManyPreferredStoreInputEnvelope
+  connect: [CustomerProfileWhereUniqueInput!]
 }
 
-input PurchaseReturnItemCreateWithoutProductVariantInput {
+input CustomerProfileCreateWithoutPreferredStoreInput {
+  fullName: String!
+  phone: String
+  email: String
+  gender: String
+  birthday: DateTime
+  profileStatus: ProfileStatus
+  requestedAt: DateTime
+  activatedAt: DateTime
+  isPhoneVerified: Boolean
+  phoneVerificationCode: String
+  phoneVerificationCodeExpiry: DateTime
+  user: UserCreateNestedOneWithoutCustomerProfileInput!
+  referredBy: CustomerProfileCreateNestedOneWithoutReferralsInput
+  referrals: CustomerProfileCreateNestedManyWithoutReferredByInput
+  sales: ConsumerSaleCreateNestedManyWithoutCustomerProfileInput
+  preferences: CustomerPreferenceProfileCreateNestedOneWithoutCustomerProfileInput
+}
+
+input CustomerProfileCreateNestedOneWithoutReferralsInput {
+  create: CustomerProfileCreateWithoutReferralsInput
+  connectOrCreate: CustomerProfileCreateOrConnectWithoutReferralsInput
+  connect: CustomerProfileWhereUniqueInput
+}
+
+input CustomerProfileCreateWithoutReferralsInput {
+  fullName: String!
+  phone: String
+  email: String
+  gender: String
+  birthday: DateTime
+  profileStatus: ProfileStatus
+  requestedAt: DateTime
+  activatedAt: DateTime
+  isPhoneVerified: Boolean
+  phoneVerificationCode: String
+  phoneVerificationCodeExpiry: DateTime
+  user: UserCreateNestedOneWithoutCustomerProfileInput!
+  preferredStore: StoreCreateNestedOneWithoutCustomerProfileInput
+  referredBy: CustomerProfileCreateNestedOneWithoutReferralsInput
+  sales: ConsumerSaleCreateNestedManyWithoutCustomerProfileInput
+  preferences: CustomerPreferenceProfileCreateNestedOneWithoutCustomerProfileInput
+}
+
+input ConsumerSaleCreateNestedManyWithoutCustomerProfileInput {
+  create: [ConsumerSaleCreateWithoutCustomerProfileInput!]
+  connectOrCreate: [ConsumerSaleCreateOrConnectWithoutCustomerProfileInput!]
+  connect: [ConsumerSaleWhereUniqueInput!]
+}
+
+input ConsumerSaleCreateWithoutCustomerProfileInput {
   id: String
-  quantity: Int!
-  return: PurchaseReturnCreateNestedOneWithoutItemsInput!
-  batch: StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput!
+  channel: SaleChannel!
+  status: SaleStatus!
+  totalAmount: Float!
+  adjustmentType: AdjustmentType
+  createdAt: DateTime
+  updatedAt: DateTime
+  customer: CustomerCreateNestedOneWithoutSalesInput
+  store: StoreCreateNestedOneWithoutCustomerSalesInput!
+  biller: UserCreateNestedOneWithoutConsumerSaleInput!
+  adjustedBy: UserCreateNestedOneWithoutConsumerSaleAdjustedBysInput
+  quotation: QuotationCreateNestedOneWithoutConsumerSaleInput
+  items: ConsumerSaleItemCreateNestedManyWithoutSaleInput
+  payments: ConsumerPaymentCreateNestedManyWithoutSaleInput
+  receipt: ConsumerReceiptCreateNestedOneWithoutSaleInput
+  SalesReturn: SalesReturnCreateNestedManyWithoutConsumerSaleInput
+  SaleOrder: SaleOrderCreateNestedOneWithoutConsumerSaleInput!
 }
 
-input PurchaseReturnCreateNestedOneWithoutItemsInput {
-  create: PurchaseReturnCreateWithoutItemsInput
-  connectOrCreate: PurchaseReturnCreateOrConnectWithoutItemsInput
-  connect: PurchaseReturnWhereUniqueInput
+input SalesReturnCreateNestedManyWithoutConsumerSaleInput {
+  create: [SalesReturnCreateWithoutConsumerSaleInput!]
+  connectOrCreate: [SalesReturnCreateOrConnectWithoutConsumerSaleInput!]
+  createMany: SalesReturnCreateManyConsumerSaleInputEnvelope
+  connect: [SalesReturnWhereUniqueInput!]
 }
 
-input PurchaseReturnCreateWithoutItemsInput {
+input SalesReturnCreateWithoutConsumerSaleInput {
+  id: String
+  type: SaleType!
+  status: ReturnStatus!
+  returnLocation: ReturnLocation!
+  isApprovedLate: Boolean
+  createdAt: DateTime
+  updatedAt: DateTime
+  resellerSale: ResellerSaleCreateNestedOneWithoutSalesReturnInput
+  returnedBy: UserCreateNestedOneWithoutSalesReturnRequestersInput!
+  receivedBy: UserCreateNestedOneWithoutSalesReturnReceiversInput!
+  approvedBy: UserCreateNestedOneWithoutSalesReturnInput
+  store: StoreCreateNestedOneWithoutSalesReturnsInput!
+  items: SalesReturnItemCreateNestedManyWithoutReturnInput
+}
+
+input StoreCreateNestedOneWithoutSalesReturnsInput {
+  create: StoreCreateWithoutSalesReturnsInput
+  connectOrCreate: StoreCreateOrConnectWithoutSalesReturnsInput
+  connect: StoreWhereUniqueInput
+}
+
+input StoreCreateWithoutSalesReturnsInput {
+  id: String
+  name: String!
+  location: String
+  isMain: Boolean
+  createdAt: DateTime
+  updatedAt: DateTime
+  manager: UserCreateNestedOneWithoutStoreInput!
+  stocks: StockCreateNestedManyWithoutStoreInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutStoreInput
+  transfersOut: StockTransferCreateNestedManyWithoutFromStoreInput
+  transfersIn: StockTransferCreateNestedManyWithoutToStoreInput
+  customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
+  resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
+  movements: StockMovementCreateNestedManyWithoutStoreInput
+  Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
+  CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
+  Quotation: QuotationCreateNestedManyWithoutStoreInput
+  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
+}
+
+input QuotationCreateNestedManyWithoutStoreInput {
+  create: [QuotationCreateWithoutStoreInput!]
+  connectOrCreate: [QuotationCreateOrConnectWithoutStoreInput!]
+  createMany: QuotationCreateManyStoreInputEnvelope
+  connect: [QuotationWhereUniqueInput!]
+}
+
+input QuotationCreateWithoutStoreInput {
+  id: String
+  type: SaleType!
+  channel: SaleChannel!
+  status: QuotationStatus
+  totalAmount: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  biller: UserCreateNestedOneWithoutBillerQuotationInput
+  consumer: CustomerCreateNestedOneWithoutQuotationInput
+  reseller: UserCreateNestedOneWithoutResellerQuotationInput
+  items: QuotationItemCreateNestedManyWithoutQuotationInput
+  sale: ResellerSaleCreateNestedOneWithoutQuotationInput
+  SaleOrder: SaleOrderCreateNestedOneWithoutQuotationInput
+  ConsumerSale: ConsumerSaleCreateNestedManyWithoutQuotationInput
+}
+
+input UserCreateNestedOneWithoutResellerQuotationInput {
+  create: UserCreateWithoutResellerQuotationInput
+  connectOrCreate: UserCreateOrConnectWithoutResellerQuotationInput
+  connect: UserWhereUniqueInput
+}
+
+input UserCreateWithoutResellerQuotationInput {
+  id: String
+  email: String!
+  passwordHash: String!
+  tier: UserTier
+  referralCode: String
+  referredBy: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  isEmailVerified: Boolean
+  emailVerificationToken: String
+  emailVerificationTokenExpiry: DateTime
+  role: RoleCreateNestedOneWithoutUsersInput!
+  resellerProfile: ResellerProfileCreateNestedOneWithoutUserInput
+  customerProfile: CustomerProfileCreateNestedOneWithoutUserInput
+  resellerPaymentsMade: ResellerPaymentCreateNestedManyWithoutResellerInput
+  resellerPaymentsReceived: ResellerPaymentCreateNestedManyWithoutReceivedByInput
+  adminLogs: AdminActionLogCreateNestedManyWithoutAdminInput
+  supportMessages: SupportMessageCreateNestedManyWithoutUserInput
+  ConsumerSale: ConsumerSaleCreateNestedManyWithoutBillerInput
+  ConsumerSaleAdjustedBys: ConsumerSaleCreateNestedManyWithoutAdjustedByInput
+  StockReceiptBatchReceivedBys: StockReceiptBatchCreateNestedManyWithoutReceivedByInput
+  StockReceiptBatchConfirmedBys: StockReceiptBatchCreateNestedManyWithoutConfirmedByInput
+  StockTransferRequests: StockTransferCreateNestedManyWithoutRequestedByInput
+  StockTransferApprovals: StockTransferCreateNestedManyWithoutApprovedByInput
+  Store: StoreCreateNestedManyWithoutManagerInput
+  ConsumerReceipt: ConsumerReceiptCreateNestedManyWithoutIssuedByInput
+  ResellerSales: ResellerSaleCreateNestedManyWithoutResellerInput
+  BillerResellerSale: ResellerSaleCreateNestedManyWithoutBillerInput
+  ResellerSale: ResellerSaleCreateNestedManyWithoutApprovedByInput
+  SalesReturnReceivers: SalesReturnCreateNestedManyWithoutReceivedByInput
+  SalesReturnRequesters: SalesReturnCreateNestedManyWithoutReturnedByInput
+  SalesReturn: SalesReturnCreateNestedManyWithoutApprovedByInput
+  PurchaseReturnInitiators: PurchaseReturnCreateNestedManyWithoutInitiatedByInput
+  PurchaseReturnApprovers: PurchaseReturnCreateNestedManyWithoutApprovedByInput
+  Payment: PaymentCreateNestedManyWithoutReceivedByInput
+  ResellerTierHistory: ResellerTierHistoryCreateNestedManyWithoutUserInput
+  ResellerTierHistoryChangedBys: ResellerTierHistoryCreateNestedManyWithoutAdminInput
+  ResellerProfile: ResellerProfileCreateNestedManyWithoutBillerInput
+  Notification: NotificationCreateNestedManyWithoutUserInput
+  Fulfillment: FulfillmentCreateNestedManyWithoutDeliveryPersonnelInput
+  BillerQuotation: QuotationCreateNestedManyWithoutBillerInput
+  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutRequestedByInput
+  Supplier: SupplierCreateNestedManyWithoutUserInput
+}
+
+input PurchaseReturnCreateNestedManyWithoutApprovedByInput {
+  create: [PurchaseReturnCreateWithoutApprovedByInput!]
+  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutApprovedByInput!]
+  createMany: PurchaseReturnCreateManyApprovedByInputEnvelope
+  connect: [PurchaseReturnWhereUniqueInput!]
+}
+
+input PurchaseReturnCreateWithoutApprovedByInput {
   id: String
   status: ReturnStatus!
   reason: String
@@ -8138,7 +8392,7 @@ input PurchaseReturnCreateWithoutItemsInput {
   updatedAt: DateTime
   supplier: SupplierCreateNestedOneWithoutReturnsInput!
   initiatedBy: UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput!
-  approvedBy: UserCreateNestedOneWithoutPurchaseReturnApproversInput!
+  items: PurchaseReturnItemCreateNestedManyWithoutReturnInput
 }
 
 input UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput {
@@ -8181,491 +8435,6 @@ input UserCreateWithoutPurchaseReturnInitiatorsInput {
   SalesReturnRequesters: SalesReturnCreateNestedManyWithoutReturnedByInput
   SalesReturn: SalesReturnCreateNestedManyWithoutApprovedByInput
   PurchaseReturnApprovers: PurchaseReturnCreateNestedManyWithoutApprovedByInput
-  Payment: PaymentCreateNestedManyWithoutReceivedByInput
-  ResellerTierHistory: ResellerTierHistoryCreateNestedManyWithoutUserInput
-  ResellerTierHistoryChangedBys: ResellerTierHistoryCreateNestedManyWithoutAdminInput
-  ResellerProfile: ResellerProfileCreateNestedManyWithoutBillerInput
-  Notification: NotificationCreateNestedManyWithoutUserInput
-  Fulfillment: FulfillmentCreateNestedManyWithoutDeliveryPersonnelInput
-  BillerQuotation: QuotationCreateNestedManyWithoutBillerInput
-  ResellerQuotation: QuotationCreateNestedManyWithoutResellerInput
-  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutRequestedByInput
-  Supplier: SupplierCreateNestedManyWithoutUserInput
-}
-
-input PurchaseReturnCreateNestedManyWithoutApprovedByInput {
-  create: [PurchaseReturnCreateWithoutApprovedByInput!]
-  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutApprovedByInput!]
-  createMany: PurchaseReturnCreateManyApprovedByInputEnvelope
-  connect: [PurchaseReturnWhereUniqueInput!]
-}
-
-input PurchaseReturnCreateWithoutApprovedByInput {
-  id: String
-  status: ReturnStatus!
-  reason: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  supplier: SupplierCreateNestedOneWithoutReturnsInput!
-  initiatedBy: UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput!
-  items: PurchaseReturnItemCreateNestedManyWithoutReturnInput
-}
-
-input PurchaseReturnItemCreateNestedManyWithoutReturnInput {
-  create: [PurchaseReturnItemCreateWithoutReturnInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutReturnInput!]
-  createMany: PurchaseReturnItemCreateManyReturnInputEnvelope
-  connect: [PurchaseReturnItemWhereUniqueInput!]
-}
-
-input PurchaseReturnItemCreateWithoutReturnInput {
-  id: String
-  quantity: Int!
-  productVariant: ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput!
-  batch: StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput!
-}
-
-input ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput {
-  create: ProductVariantCreateWithoutPurchaseReturnItemsInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput
-  connect: ProductVariantWhereUniqueInput
-}
-
-input ProductVariantCreateWithoutPurchaseReturnItemsInput {
-  id: String
-  size: String!
-  concentration: String!
-  packaging: String!
-  barcode: String
-  price: Float!
-  resellerPrice: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  product: ProductCreateNestedOneWithoutVariantsInput!
-  stockItems: StockCreateNestedManyWithoutProductVariantInput
-  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
-  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
-  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
-  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
-  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
-  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
-  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
-  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
-  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
-  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
-  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
-}
-
-input StockTransferItemCreateNestedManyWithoutProductVariantInput {
-  create: [StockTransferItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [StockTransferItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: StockTransferItemCreateManyProductVariantInputEnvelope
-  connect: [StockTransferItemWhereUniqueInput!]
-}
-
-input StockTransferItemCreateWithoutProductVariantInput {
-  id: String
-  quantity: Int!
-  transfer: StockTransferCreateNestedOneWithoutItemsInput!
-}
-
-input StockTransferCreateNestedOneWithoutItemsInput {
-  create: StockTransferCreateWithoutItemsInput
-  connectOrCreate: StockTransferCreateOrConnectWithoutItemsInput
-  connect: StockTransferWhereUniqueInput
-}
-
-input StockTransferCreateWithoutItemsInput {
-  id: String
-  status: TransferStatus!
-  createdAt: DateTime
-  fromStore: StoreCreateNestedOneWithoutTransfersOutInput!
-  toStore: StoreCreateNestedOneWithoutTransfersInInput!
-  requestedBy: UserCreateNestedOneWithoutStockTransferRequestsInput!
-  approvedBy: UserCreateNestedOneWithoutStockTransferApprovalsInput!
-}
-
-input StockTransferCreateOrConnectWithoutItemsInput {
-  where: StockTransferWhereUniqueInput!
-  create: StockTransferCreateWithoutItemsInput!
-}
-
-input StockTransferWhereUniqueInput {
-  id: String
-  AND: [StockTransferWhereInput!]
-  OR: [StockTransferWhereInput!]
-  NOT: [StockTransferWhereInput!]
-  fromStoreId: StringFilter
-  toStoreId: StringFilter
-  requestedById: StringFilter
-  approvedById: StringFilter
-  status: EnumTransferStatusFilter
-  createdAt: DateTimeFilter
-  fromStore: StoreScalarRelationFilter
-  toStore: StoreScalarRelationFilter
-  requestedBy: UserScalarRelationFilter
-  approvedBy: UserScalarRelationFilter
-  items: StockTransferItemListRelationFilter
-}
-
-input StockTransferItemCreateOrConnectWithoutProductVariantInput {
-  where: StockTransferItemWhereUniqueInput!
-  create: StockTransferItemCreateWithoutProductVariantInput!
-}
-
-input StockTransferItemWhereUniqueInput {
-  id: String
-  AND: [StockTransferItemWhereInput!]
-  OR: [StockTransferItemWhereInput!]
-  NOT: [StockTransferItemWhereInput!]
-  stockTransferId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  transfer: StockTransferScalarRelationFilter
-  productVariant: ProductVariantScalarRelationFilter
-}
-
-input StockTransferItemCreateManyProductVariantInputEnvelope {
-  data: [StockTransferItemCreateManyProductVariantInput!]!
-  skipDuplicates: Boolean
-}
-
-input StockTransferItemCreateManyProductVariantInput {
-  id: String
-  stockTransferId: String!
-  quantity: Int!
-}
-
-input ProductSalesStatsCreateNestedOneWithoutProductVariantInput {
-  create: ProductSalesStatsCreateWithoutProductVariantInput
-  connectOrCreate: ProductSalesStatsCreateOrConnectWithoutProductVariantInput
-  connect: ProductSalesStatsWhereUniqueInput
-}
-
-input ProductSalesStatsCreateWithoutProductVariantInput {
-  id: String
-  totalSold: Int
-  totalReturned: Int
-  lastSoldAt: DateTime
-  monthlySales: JSON!
-}
-
-input ProductSalesStatsCreateOrConnectWithoutProductVariantInput {
-  where: ProductSalesStatsWhereUniqueInput!
-  create: ProductSalesStatsCreateWithoutProductVariantInput!
-}
-
-input ProductSalesStatsWhereUniqueInput {
-  id: String
-  productVariantId: String
-  AND: [ProductSalesStatsWhereInput!]
-  OR: [ProductSalesStatsWhereInput!]
-  NOT: [ProductSalesStatsWhereInput!]
-  totalSold: IntFilter
-  totalReturned: IntFilter
-  lastSoldAt: DateTimeNullableFilter
-  monthlySales: JsonFilter
-  productVariant: ProductVariantScalarRelationFilter
-}
-
-input PurchaseOrderItemCreateNestedManyWithoutProductVariantInput {
-  create: [PurchaseOrderItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: PurchaseOrderItemCreateManyProductVariantInputEnvelope
-  connect: [PurchaseOrderItemWhereUniqueInput!]
-}
-
-input PurchaseOrderItemCreateWithoutProductVariantInput {
-  id: String
-  quantity: Int!
-  unitCost: Float!
-  purchaseOrder: PurchaseOrderCreateNestedOneWithoutItemsInput!
-}
-
-input PurchaseOrderCreateNestedOneWithoutItemsInput {
-  create: PurchaseOrderCreateWithoutItemsInput
-  connectOrCreate: PurchaseOrderCreateOrConnectWithoutItemsInput
-  connect: PurchaseOrderWhereUniqueInput
-}
-
-input PurchaseOrderCreateWithoutItemsInput {
-  id: String
-  invoiceNumber: String!
-  status: PurchaseOrderStatus!
-  phase: PurchasePhase
-  dueDate: DateTime!
-  totalAmount: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
-  receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
-  payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
-}
-
-input SupplierCreateNestedOneWithoutPurchaseOrdersInput {
-  create: SupplierCreateWithoutPurchaseOrdersInput
-  connectOrCreate: SupplierCreateOrConnectWithoutPurchaseOrdersInput
-  connect: SupplierWhereUniqueInput
-}
-
-input SupplierCreateWithoutPurchaseOrdersInput {
-  id: String
-  name: String!
-  contactInfo: JSON
-  isFrequent: Boolean
-  creditLimit: Float!
-  currentBalance: Float
-  paymentTerms: String
-  notes: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  payments: SupplierPaymentCreateNestedManyWithoutSupplierInput
-  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
-  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
-  quotes: SupplierQuoteCreateNestedManyWithoutSupplierInput
-  user: UserCreateNestedOneWithoutSupplierInput
-}
-
-input SupplierPaymentCreateNestedManyWithoutSupplierInput {
-  create: [SupplierPaymentCreateWithoutSupplierInput!]
-  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutSupplierInput!]
-  createMany: SupplierPaymentCreateManySupplierInputEnvelope
-  connect: [SupplierPaymentWhereUniqueInput!]
-}
-
-input SupplierPaymentCreateWithoutSupplierInput {
-  id: String
-  amount: Float!
-  paymentDate: DateTime!
-  method: String!
-  notes: String
-  purchaseOrder: PurchaseOrderCreateNestedOneWithoutPaymentsInput
-}
-
-input PurchaseOrderCreateNestedOneWithoutPaymentsInput {
-  create: PurchaseOrderCreateWithoutPaymentsInput
-  connectOrCreate: PurchaseOrderCreateOrConnectWithoutPaymentsInput
-  connect: PurchaseOrderWhereUniqueInput
-}
-
-input PurchaseOrderCreateWithoutPaymentsInput {
-  id: String
-  invoiceNumber: String!
-  status: PurchaseOrderStatus!
-  phase: PurchasePhase
-  dueDate: DateTime!
-  totalAmount: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
-  items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
-  receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
-}
-
-input StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput {
-  create: [StockReceiptBatchCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput!]
-  connect: [StockReceiptBatchWhereUniqueInput!]
-}
-
-input StockReceiptBatchCreateWithoutPurchaseOrderInput {
-  id: String
-  purchaseOrderId: String!
-  waybillUrl: String
-  receivedAt: DateTime
-  store: StoreCreateNestedOneWithoutReceiptsInput!
-  receivedBy: UserCreateNestedOneWithoutStockReceiptBatchReceivedBysInput!
-  confirmedBy: UserCreateNestedOneWithoutStockReceiptBatchConfirmedBysInput!
-  items: StockReceiptBatchItemCreateNestedManyWithoutBatchInput
-  purchaseReturns: PurchaseReturnItemCreateNestedManyWithoutBatchInput
-}
-
-input PurchaseReturnItemCreateNestedManyWithoutBatchInput {
-  create: [PurchaseReturnItemCreateWithoutBatchInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutBatchInput!]
-  createMany: PurchaseReturnItemCreateManyBatchInputEnvelope
-  connect: [PurchaseReturnItemWhereUniqueInput!]
-}
-
-input PurchaseReturnItemCreateWithoutBatchInput {
-  id: String
-  quantity: Int!
-  return: PurchaseReturnCreateNestedOneWithoutItemsInput!
-  productVariant: ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput!
-}
-
-input PurchaseReturnItemCreateOrConnectWithoutBatchInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  create: PurchaseReturnItemCreateWithoutBatchInput!
-}
-
-input PurchaseReturnItemWhereUniqueInput {
-  id: String
-  AND: [PurchaseReturnItemWhereInput!]
-  OR: [PurchaseReturnItemWhereInput!]
-  NOT: [PurchaseReturnItemWhereInput!]
-  purchaseReturnId: StringFilter
-  productVariantId: StringFilter
-  batchId: StringFilter
-  quantity: IntFilter
-  return: PurchaseReturnScalarRelationFilter
-  productVariant: ProductVariantScalarRelationFilter
-  batch: StockReceiptBatchScalarRelationFilter
-}
-
-input PurchaseReturnItemCreateManyBatchInputEnvelope {
-  data: [PurchaseReturnItemCreateManyBatchInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseReturnItemCreateManyBatchInput {
-  id: String
-  purchaseReturnId: String!
-  productVariantId: String!
-  quantity: Int!
-}
-
-input StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput {
-  where: StockReceiptBatchWhereUniqueInput!
-  create: StockReceiptBatchCreateWithoutPurchaseOrderInput!
-}
-
-input StockReceiptBatchWhereUniqueInput {
-  id: String
-  AND: [StockReceiptBatchWhereInput!]
-  OR: [StockReceiptBatchWhereInput!]
-  NOT: [StockReceiptBatchWhereInput!]
-  purchaseOrderId: StringFilter
-  storeId: StringFilter
-  receivedById: StringFilter
-  confirmedById: StringFilter
-  waybillUrl: StringNullableFilter
-  receivedAt: DateTimeFilter
-  store: StoreScalarRelationFilter
-  receivedBy: UserScalarRelationFilter
-  confirmedBy: UserScalarRelationFilter
-  items: StockReceiptBatchItemListRelationFilter
-  purchaseReturns: PurchaseReturnItemListRelationFilter
-  PurchaseOrder: PurchaseOrderListRelationFilter
-}
-
-input PurchaseOrderCreateOrConnectWithoutPaymentsInput {
-  where: PurchaseOrderWhereUniqueInput!
-  create: PurchaseOrderCreateWithoutPaymentsInput!
-}
-
-input PurchaseOrderWhereUniqueInput {
-  id: String
-  AND: [PurchaseOrderWhereInput!]
-  OR: [PurchaseOrderWhereInput!]
-  NOT: [PurchaseOrderWhereInput!]
-  supplierId: StringFilter
-  invoiceNumber: StringFilter
-  status: EnumPurchaseOrderStatusFilter
-  phase: EnumPurchasePhaseFilter
-  dueDate: DateTimeFilter
-  totalAmount: FloatFilter
-  createdAt: DateTimeFilter
-  updatedAt: DateTimeFilter
-  supplier: SupplierScalarRelationFilter
-  items: PurchaseOrderItemListRelationFilter
-  receipts: StockReceiptBatchListRelationFilter
-  payments: SupplierPaymentListRelationFilter
-}
-
-input SupplierPaymentCreateOrConnectWithoutSupplierInput {
-  where: SupplierPaymentWhereUniqueInput!
-  create: SupplierPaymentCreateWithoutSupplierInput!
-}
-
-input SupplierPaymentWhereUniqueInput {
-  id: String
-  AND: [SupplierPaymentWhereInput!]
-  OR: [SupplierPaymentWhereInput!]
-  NOT: [SupplierPaymentWhereInput!]
-  supplierId: StringFilter
-  purchaseOrderId: StringNullableFilter
-  amount: FloatFilter
-  paymentDate: DateTimeFilter
-  method: StringFilter
-  notes: StringNullableFilter
-  supplier: SupplierScalarRelationFilter
-  purchaseOrder: PurchaseOrderNullableScalarRelationFilter
-}
-
-input SupplierPaymentCreateManySupplierInputEnvelope {
-  data: [SupplierPaymentCreateManySupplierInput!]!
-  skipDuplicates: Boolean
-}
-
-input SupplierPaymentCreateManySupplierInput {
-  id: String
-  purchaseOrderId: String
-  amount: Float!
-  paymentDate: DateTime!
-  method: String!
-  notes: String
-}
-
-input PurchaseReturnCreateNestedManyWithoutSupplierInput {
-  create: [PurchaseReturnCreateWithoutSupplierInput!]
-  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutSupplierInput!]
-  createMany: PurchaseReturnCreateManySupplierInputEnvelope
-  connect: [PurchaseReturnWhereUniqueInput!]
-}
-
-input PurchaseReturnCreateWithoutSupplierInput {
-  id: String
-  status: ReturnStatus!
-  reason: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  initiatedBy: UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput!
-  approvedBy: UserCreateNestedOneWithoutPurchaseReturnApproversInput!
-  items: PurchaseReturnItemCreateNestedManyWithoutReturnInput
-}
-
-input UserCreateNestedOneWithoutPurchaseReturnApproversInput {
-  create: UserCreateWithoutPurchaseReturnApproversInput
-  connectOrCreate: UserCreateOrConnectWithoutPurchaseReturnApproversInput
-  connect: UserWhereUniqueInput
-}
-
-input UserCreateWithoutPurchaseReturnApproversInput {
-  id: String
-  email: String!
-  passwordHash: String!
-  tier: UserTier
-  referralCode: String
-  referredBy: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  isEmailVerified: Boolean
-  emailVerificationToken: String
-  emailVerificationTokenExpiry: DateTime
-  role: RoleCreateNestedOneWithoutUsersInput!
-  resellerProfile: ResellerProfileCreateNestedOneWithoutUserInput
-  customerProfile: CustomerProfileCreateNestedOneWithoutUserInput
-  resellerPaymentsMade: ResellerPaymentCreateNestedManyWithoutResellerInput
-  resellerPaymentsReceived: ResellerPaymentCreateNestedManyWithoutReceivedByInput
-  adminLogs: AdminActionLogCreateNestedManyWithoutAdminInput
-  supportMessages: SupportMessageCreateNestedManyWithoutUserInput
-  ConsumerSale: ConsumerSaleCreateNestedManyWithoutBillerInput
-  ConsumerSaleAdjustedBys: ConsumerSaleCreateNestedManyWithoutAdjustedByInput
-  StockReceiptBatchReceivedBys: StockReceiptBatchCreateNestedManyWithoutReceivedByInput
-  StockReceiptBatchConfirmedBys: StockReceiptBatchCreateNestedManyWithoutConfirmedByInput
-  StockTransferRequests: StockTransferCreateNestedManyWithoutRequestedByInput
-  StockTransferApprovals: StockTransferCreateNestedManyWithoutApprovedByInput
-  Store: StoreCreateNestedManyWithoutManagerInput
-  ConsumerReceipt: ConsumerReceiptCreateNestedManyWithoutIssuedByInput
-  ResellerSales: ResellerSaleCreateNestedManyWithoutResellerInput
-  BillerResellerSale: ResellerSaleCreateNestedManyWithoutBillerInput
-  ResellerSale: ResellerSaleCreateNestedManyWithoutApprovedByInput
-  SalesReturnReceivers: SalesReturnCreateNestedManyWithoutReceivedByInput
-  SalesReturnRequesters: SalesReturnCreateNestedManyWithoutReturnedByInput
-  SalesReturn: SalesReturnCreateNestedManyWithoutApprovedByInput
-  PurchaseReturnInitiators: PurchaseReturnCreateNestedManyWithoutInitiatedByInput
   Payment: PaymentCreateNestedManyWithoutReceivedByInput
   ResellerTierHistory: ResellerTierHistoryCreateNestedManyWithoutUserInput
   ResellerTierHistoryChangedBys: ResellerTierHistoryCreateNestedManyWithoutAdminInput
@@ -8974,13 +8743,91 @@ input QuotationCreateWithoutSaleOrderInput {
   ConsumerSale: ConsumerSaleCreateNestedManyWithoutQuotationInput
 }
 
-input UserCreateNestedOneWithoutResellerQuotationInput {
-  create: UserCreateWithoutResellerQuotationInput
-  connectOrCreate: UserCreateOrConnectWithoutResellerQuotationInput
+input QuotationItemCreateNestedManyWithoutQuotationInput {
+  create: [QuotationItemCreateWithoutQuotationInput!]
+  connectOrCreate: [QuotationItemCreateOrConnectWithoutQuotationInput!]
+  createMany: QuotationItemCreateManyQuotationInputEnvelope
+  connect: [QuotationItemWhereUniqueInput!]
+}
+
+input QuotationItemCreateWithoutQuotationInput {
+  id: String
+  quantity: Int!
+  unitPrice: Float!
+  productVariant: ProductVariantCreateNestedOneWithoutQuotationItemsInput!
+}
+
+input ProductVariantCreateNestedOneWithoutQuotationItemsInput {
+  create: ProductVariantCreateWithoutQuotationItemsInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutQuotationItemsInput
+  connect: ProductVariantWhereUniqueInput
+}
+
+input ProductVariantCreateWithoutQuotationItemsInput {
+  id: String
+  size: String!
+  concentration: String!
+  packaging: String!
+  barcode: String
+  price: Float!
+  resellerPrice: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  product: ProductCreateNestedOneWithoutVariantsInput!
+  stockItems: StockCreateNestedManyWithoutProductVariantInput
+  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
+  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
+  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
+  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
+  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
+  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
+  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
+  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
+  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
+  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
+  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
+}
+
+input PurchaseReturnItemCreateNestedManyWithoutProductVariantInput {
+  create: [PurchaseReturnItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: PurchaseReturnItemCreateManyProductVariantInputEnvelope
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+}
+
+input PurchaseReturnItemCreateWithoutProductVariantInput {
+  id: String
+  quantity: Int!
+  return: PurchaseReturnCreateNestedOneWithoutItemsInput!
+  batch: StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput!
+}
+
+input PurchaseReturnCreateNestedOneWithoutItemsInput {
+  create: PurchaseReturnCreateWithoutItemsInput
+  connectOrCreate: PurchaseReturnCreateOrConnectWithoutItemsInput
+  connect: PurchaseReturnWhereUniqueInput
+}
+
+input PurchaseReturnCreateWithoutItemsInput {
+  id: String
+  status: ReturnStatus!
+  reason: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  supplier: SupplierCreateNestedOneWithoutReturnsInput!
+  initiatedBy: UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput!
+  approvedBy: UserCreateNestedOneWithoutPurchaseReturnApproversInput!
+}
+
+input UserCreateNestedOneWithoutPurchaseReturnApproversInput {
+  create: UserCreateWithoutPurchaseReturnApproversInput
+  connectOrCreate: UserCreateOrConnectWithoutPurchaseReturnApproversInput
   connect: UserWhereUniqueInput
 }
 
-input UserCreateWithoutResellerQuotationInput {
+input UserCreateWithoutPurchaseReturnApproversInput {
   id: String
   email: String!
   passwordHash: String!
@@ -9014,7 +8861,6 @@ input UserCreateWithoutResellerQuotationInput {
   SalesReturnRequesters: SalesReturnCreateNestedManyWithoutReturnedByInput
   SalesReturn: SalesReturnCreateNestedManyWithoutApprovedByInput
   PurchaseReturnInitiators: PurchaseReturnCreateNestedManyWithoutInitiatedByInput
-  PurchaseReturnApprovers: PurchaseReturnCreateNestedManyWithoutApprovedByInput
   Payment: PaymentCreateNestedManyWithoutReceivedByInput
   ResellerTierHistory: ResellerTierHistoryCreateNestedManyWithoutUserInput
   ResellerTierHistoryChangedBys: ResellerTierHistoryCreateNestedManyWithoutAdminInput
@@ -9022,6 +8868,7 @@ input UserCreateWithoutResellerQuotationInput {
   Notification: NotificationCreateNestedManyWithoutUserInput
   Fulfillment: FulfillmentCreateNestedManyWithoutDeliveryPersonnelInput
   BillerQuotation: QuotationCreateNestedManyWithoutBillerInput
+  ResellerQuotation: QuotationCreateNestedManyWithoutResellerInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutRequestedByInput
   Supplier: SupplierCreateNestedManyWithoutUserInput
 }
@@ -9109,259 +8956,6 @@ input QuotationCreateWithoutBillerInput {
   createdAt: DateTime
   updatedAt: DateTime
   store: StoreCreateNestedOneWithoutQuotationInput!
-  consumer: CustomerCreateNestedOneWithoutQuotationInput
-  reseller: UserCreateNestedOneWithoutResellerQuotationInput
-  items: QuotationItemCreateNestedManyWithoutQuotationInput
-  sale: ResellerSaleCreateNestedOneWithoutQuotationInput
-  SaleOrder: SaleOrderCreateNestedOneWithoutQuotationInput
-  ConsumerSale: ConsumerSaleCreateNestedManyWithoutQuotationInput
-}
-
-input QuotationItemCreateNestedManyWithoutQuotationInput {
-  create: [QuotationItemCreateWithoutQuotationInput!]
-  connectOrCreate: [QuotationItemCreateOrConnectWithoutQuotationInput!]
-  createMany: QuotationItemCreateManyQuotationInputEnvelope
-  connect: [QuotationItemWhereUniqueInput!]
-}
-
-input QuotationItemCreateWithoutQuotationInput {
-  id: String
-  quantity: Int!
-  unitPrice: Float!
-  productVariant: ProductVariantCreateNestedOneWithoutQuotationItemsInput!
-}
-
-input ProductVariantCreateNestedOneWithoutQuotationItemsInput {
-  create: ProductVariantCreateWithoutQuotationItemsInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutQuotationItemsInput
-  connect: ProductVariantWhereUniqueInput
-}
-
-input ProductVariantCreateWithoutQuotationItemsInput {
-  id: String
-  size: String!
-  concentration: String!
-  packaging: String!
-  barcode: String
-  price: Float!
-  resellerPrice: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  product: ProductCreateNestedOneWithoutVariantsInput!
-  stockItems: StockCreateNestedManyWithoutProductVariantInput
-  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
-  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
-  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
-  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
-  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
-  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
-  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
-  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
-  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
-  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
-  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
-}
-
-input StockMovementItemCreateNestedManyWithoutProductVariantInput {
-  create: [StockMovementItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [StockMovementItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: StockMovementItemCreateManyProductVariantInputEnvelope
-  connect: [StockMovementItemWhereUniqueInput!]
-}
-
-input StockMovementItemCreateWithoutProductVariantInput {
-  id: String
-  quantity: Int!
-  movement: StockMovementCreateNestedOneWithoutItemsInput!
-}
-
-input StockMovementCreateNestedOneWithoutItemsInput {
-  create: StockMovementCreateWithoutItemsInput
-  connectOrCreate: StockMovementCreateOrConnectWithoutItemsInput
-  connect: StockMovementWhereUniqueInput
-}
-
-input StockMovementCreateWithoutItemsInput {
-  id: String
-  direction: MovementDirection!
-  movementType: MovementType!
-  referenceEntity: String!
-  referenceId: String!
-  createdAt: DateTime
-  store: StoreCreateNestedOneWithoutMovementsInput!
-}
-
-input StoreCreateNestedOneWithoutMovementsInput {
-  create: StoreCreateWithoutMovementsInput
-  connectOrCreate: StoreCreateOrConnectWithoutMovementsInput
-  connect: StoreWhereUniqueInput
-}
-
-input StoreCreateWithoutMovementsInput {
-  id: String
-  name: String!
-  location: String
-  isMain: Boolean
-  createdAt: DateTime
-  updatedAt: DateTime
-  manager: UserCreateNestedOneWithoutStoreInput!
-  stocks: StockCreateNestedManyWithoutStoreInput
-  receipts: StockReceiptBatchCreateNestedManyWithoutStoreInput
-  transfersOut: StockTransferCreateNestedManyWithoutFromStoreInput
-  transfersIn: StockTransferCreateNestedManyWithoutToStoreInput
-  customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
-  salesReturns: SalesReturnCreateNestedManyWithoutStoreInput
-  resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
-  Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
-  CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
-  Quotation: QuotationCreateNestedManyWithoutStoreInput
-  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
-}
-
-input CustomerProfileCreateNestedManyWithoutPreferredStoreInput {
-  create: [CustomerProfileCreateWithoutPreferredStoreInput!]
-  connectOrCreate: [CustomerProfileCreateOrConnectWithoutPreferredStoreInput!]
-  createMany: CustomerProfileCreateManyPreferredStoreInputEnvelope
-  connect: [CustomerProfileWhereUniqueInput!]
-}
-
-input CustomerProfileCreateWithoutPreferredStoreInput {
-  fullName: String!
-  phone: String
-  email: String
-  gender: String
-  birthday: DateTime
-  profileStatus: ProfileStatus
-  requestedAt: DateTime
-  activatedAt: DateTime
-  isPhoneVerified: Boolean
-  phoneVerificationCode: String
-  phoneVerificationCodeExpiry: DateTime
-  user: UserCreateNestedOneWithoutCustomerProfileInput!
-  referredBy: CustomerProfileCreateNestedOneWithoutReferralsInput
-  referrals: CustomerProfileCreateNestedManyWithoutReferredByInput
-  sales: ConsumerSaleCreateNestedManyWithoutCustomerProfileInput
-  preferences: CustomerPreferenceProfileCreateNestedOneWithoutCustomerProfileInput
-}
-
-input CustomerProfileCreateNestedOneWithoutReferralsInput {
-  create: CustomerProfileCreateWithoutReferralsInput
-  connectOrCreate: CustomerProfileCreateOrConnectWithoutReferralsInput
-  connect: CustomerProfileWhereUniqueInput
-}
-
-input CustomerProfileCreateWithoutReferralsInput {
-  fullName: String!
-  phone: String
-  email: String
-  gender: String
-  birthday: DateTime
-  profileStatus: ProfileStatus
-  requestedAt: DateTime
-  activatedAt: DateTime
-  isPhoneVerified: Boolean
-  phoneVerificationCode: String
-  phoneVerificationCodeExpiry: DateTime
-  user: UserCreateNestedOneWithoutCustomerProfileInput!
-  preferredStore: StoreCreateNestedOneWithoutCustomerProfileInput
-  referredBy: CustomerProfileCreateNestedOneWithoutReferralsInput
-  sales: ConsumerSaleCreateNestedManyWithoutCustomerProfileInput
-  preferences: CustomerPreferenceProfileCreateNestedOneWithoutCustomerProfileInput
-}
-
-input ConsumerSaleCreateNestedManyWithoutCustomerProfileInput {
-  create: [ConsumerSaleCreateWithoutCustomerProfileInput!]
-  connectOrCreate: [ConsumerSaleCreateOrConnectWithoutCustomerProfileInput!]
-  connect: [ConsumerSaleWhereUniqueInput!]
-}
-
-input ConsumerSaleCreateWithoutCustomerProfileInput {
-  id: String
-  channel: SaleChannel!
-  status: SaleStatus!
-  totalAmount: Float!
-  adjustmentType: AdjustmentType
-  createdAt: DateTime
-  updatedAt: DateTime
-  customer: CustomerCreateNestedOneWithoutSalesInput
-  store: StoreCreateNestedOneWithoutCustomerSalesInput!
-  biller: UserCreateNestedOneWithoutConsumerSaleInput!
-  adjustedBy: UserCreateNestedOneWithoutConsumerSaleAdjustedBysInput
-  quotation: QuotationCreateNestedOneWithoutConsumerSaleInput
-  items: ConsumerSaleItemCreateNestedManyWithoutSaleInput
-  payments: ConsumerPaymentCreateNestedManyWithoutSaleInput
-  receipt: ConsumerReceiptCreateNestedOneWithoutSaleInput
-  SalesReturn: SalesReturnCreateNestedManyWithoutConsumerSaleInput
-  SaleOrder: SaleOrderCreateNestedOneWithoutConsumerSaleInput!
-}
-
-input SalesReturnCreateNestedManyWithoutConsumerSaleInput {
-  create: [SalesReturnCreateWithoutConsumerSaleInput!]
-  connectOrCreate: [SalesReturnCreateOrConnectWithoutConsumerSaleInput!]
-  createMany: SalesReturnCreateManyConsumerSaleInputEnvelope
-  connect: [SalesReturnWhereUniqueInput!]
-}
-
-input SalesReturnCreateWithoutConsumerSaleInput {
-  id: String
-  type: SaleType!
-  status: ReturnStatus!
-  returnLocation: ReturnLocation!
-  isApprovedLate: Boolean
-  createdAt: DateTime
-  updatedAt: DateTime
-  resellerSale: ResellerSaleCreateNestedOneWithoutSalesReturnInput
-  returnedBy: UserCreateNestedOneWithoutSalesReturnRequestersInput!
-  receivedBy: UserCreateNestedOneWithoutSalesReturnReceiversInput!
-  approvedBy: UserCreateNestedOneWithoutSalesReturnInput
-  store: StoreCreateNestedOneWithoutSalesReturnsInput!
-  items: SalesReturnItemCreateNestedManyWithoutReturnInput
-}
-
-input StoreCreateNestedOneWithoutSalesReturnsInput {
-  create: StoreCreateWithoutSalesReturnsInput
-  connectOrCreate: StoreCreateOrConnectWithoutSalesReturnsInput
-  connect: StoreWhereUniqueInput
-}
-
-input StoreCreateWithoutSalesReturnsInput {
-  id: String
-  name: String!
-  location: String
-  isMain: Boolean
-  createdAt: DateTime
-  updatedAt: DateTime
-  manager: UserCreateNestedOneWithoutStoreInput!
-  stocks: StockCreateNestedManyWithoutStoreInput
-  receipts: StockReceiptBatchCreateNestedManyWithoutStoreInput
-  transfersOut: StockTransferCreateNestedManyWithoutFromStoreInput
-  transfersIn: StockTransferCreateNestedManyWithoutToStoreInput
-  customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
-  resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
-  movements: StockMovementCreateNestedManyWithoutStoreInput
-  Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
-  CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
-  Quotation: QuotationCreateNestedManyWithoutStoreInput
-  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
-}
-
-input QuotationCreateNestedManyWithoutStoreInput {
-  create: [QuotationCreateWithoutStoreInput!]
-  connectOrCreate: [QuotationCreateOrConnectWithoutStoreInput!]
-  createMany: QuotationCreateManyStoreInputEnvelope
-  connect: [QuotationWhereUniqueInput!]
-}
-
-input QuotationCreateWithoutStoreInput {
-  id: String
-  type: SaleType!
-  channel: SaleChannel!
-  status: QuotationStatus
-  totalAmount: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  biller: UserCreateNestedOneWithoutBillerQuotationInput
   consumer: CustomerCreateNestedOneWithoutQuotationInput
   reseller: UserCreateNestedOneWithoutResellerQuotationInput
   items: QuotationItemCreateNestedManyWithoutQuotationInput
@@ -9460,45 +9054,300 @@ input ProductVariantCreateWithoutReturnItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
-input PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput {
-  create: [PurchaseRequisitionItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: PurchaseRequisitionItemCreateManyProductVariantInputEnvelope
-  connect: [PurchaseRequisitionItemWhereUniqueInput!]
+input StockTransferItemCreateNestedManyWithoutProductVariantInput {
+  create: [StockTransferItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [StockTransferItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: StockTransferItemCreateManyProductVariantInputEnvelope
+  connect: [StockTransferItemWhereUniqueInput!]
 }
 
-input PurchaseRequisitionItemCreateWithoutProductVariantInput {
+input StockTransferItemCreateWithoutProductVariantInput {
   id: String
-  requestedQty: Int!
-  notes: String
-  requisition: PurchaseRequisitionCreateNestedOneWithoutItemsInput!
+  quantity: Int!
+  transfer: StockTransferCreateNestedOneWithoutItemsInput!
 }
 
-input PurchaseRequisitionCreateNestedOneWithoutItemsInput {
-  create: PurchaseRequisitionCreateWithoutItemsInput
-  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutItemsInput
-  connect: PurchaseRequisitionWhereUniqueInput
+input StockTransferCreateNestedOneWithoutItemsInput {
+  create: StockTransferCreateWithoutItemsInput
+  connectOrCreate: StockTransferCreateOrConnectWithoutItemsInput
+  connect: StockTransferWhereUniqueInput
 }
 
-input PurchaseRequisitionCreateWithoutItemsInput {
+input StockTransferCreateWithoutItemsInput {
   id: String
-  status: PurchaseRequisitionStatus
+  status: TransferStatus!
+  createdAt: DateTime
+  fromStore: StoreCreateNestedOneWithoutTransfersOutInput!
+  toStore: StoreCreateNestedOneWithoutTransfersInInput!
+  requestedBy: UserCreateNestedOneWithoutStockTransferRequestsInput!
+  approvedBy: UserCreateNestedOneWithoutStockTransferApprovalsInput!
+}
+
+input StockTransferCreateOrConnectWithoutItemsInput {
+  where: StockTransferWhereUniqueInput!
+  create: StockTransferCreateWithoutItemsInput!
+}
+
+input StockTransferWhereUniqueInput {
+  id: String
+  AND: [StockTransferWhereInput!]
+  OR: [StockTransferWhereInput!]
+  NOT: [StockTransferWhereInput!]
+  fromStoreId: StringFilter
+  toStoreId: StringFilter
+  requestedById: StringFilter
+  approvedById: StringFilter
+  status: EnumTransferStatusFilter
+  createdAt: DateTimeFilter
+  fromStore: StoreScalarRelationFilter
+  toStore: StoreScalarRelationFilter
+  requestedBy: UserScalarRelationFilter
+  approvedBy: UserScalarRelationFilter
+  items: StockTransferItemListRelationFilter
+}
+
+input StockTransferItemCreateOrConnectWithoutProductVariantInput {
+  where: StockTransferItemWhereUniqueInput!
+  create: StockTransferItemCreateWithoutProductVariantInput!
+}
+
+input StockTransferItemWhereUniqueInput {
+  id: String
+  AND: [StockTransferItemWhereInput!]
+  OR: [StockTransferItemWhereInput!]
+  NOT: [StockTransferItemWhereInput!]
+  stockTransferId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  transfer: StockTransferScalarRelationFilter
+  productVariant: ProductVariantScalarRelationFilter
+}
+
+input StockTransferItemCreateManyProductVariantInputEnvelope {
+  data: [StockTransferItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input StockTransferItemCreateManyProductVariantInput {
+  id: String
+  stockTransferId: String!
+  quantity: Int!
+}
+
+input ProductSalesStatsCreateNestedOneWithoutProductVariantInput {
+  create: ProductSalesStatsCreateWithoutProductVariantInput
+  connectOrCreate: ProductSalesStatsCreateOrConnectWithoutProductVariantInput
+  connect: ProductSalesStatsWhereUniqueInput
+}
+
+input ProductSalesStatsCreateWithoutProductVariantInput {
+  id: String
+  totalSold: Int
+  totalReturned: Int
+  lastSoldAt: DateTime
+  monthlySales: JSON!
+}
+
+input ProductSalesStatsCreateOrConnectWithoutProductVariantInput {
+  where: ProductSalesStatsWhereUniqueInput!
+  create: ProductSalesStatsCreateWithoutProductVariantInput!
+}
+
+input ProductSalesStatsWhereUniqueInput {
+  id: String
+  productVariantId: String
+  AND: [ProductSalesStatsWhereInput!]
+  OR: [ProductSalesStatsWhereInput!]
+  NOT: [ProductSalesStatsWhereInput!]
+  totalSold: IntFilter
+  totalReturned: IntFilter
+  lastSoldAt: DateTimeNullableFilter
+  monthlySales: JsonFilter
+  productVariant: ProductVariantScalarRelationFilter
+}
+
+input PurchaseOrderItemCreateNestedManyWithoutProductVariantInput {
+  create: [PurchaseOrderItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: PurchaseOrderItemCreateManyProductVariantInputEnvelope
+  connect: [PurchaseOrderItemWhereUniqueInput!]
+}
+
+input PurchaseOrderItemCreateWithoutProductVariantInput {
+  id: String
+  quantity: Int!
+  unitCost: Float!
+  purchaseOrder: PurchaseOrderCreateNestedOneWithoutItemsInput!
+}
+
+input PurchaseOrderCreateNestedOneWithoutItemsInput {
+  create: PurchaseOrderCreateWithoutItemsInput
+  connectOrCreate: PurchaseOrderCreateOrConnectWithoutItemsInput
+  connect: PurchaseOrderWhereUniqueInput
+}
+
+input PurchaseOrderCreateWithoutItemsInput {
+  id: String
+  invoiceNumber: String!
+  status: PurchaseOrderStatus!
+  phase: PurchasePhase
+  dueDate: DateTime!
+  totalAmount: Float!
   createdAt: DateTime
   updatedAt: DateTime
-  store: StoreCreateNestedOneWithoutPurchaseRequisitionInput!
-  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
-  quotes: SupplierQuoteCreateNestedManyWithoutRequisitionInput
+  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
+  store: StoreCreateNestedOneWithoutPurchaseOrdersInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
+  payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
 }
 
-input StoreCreateNestedOneWithoutPurchaseRequisitionInput {
-  create: StoreCreateWithoutPurchaseRequisitionInput
-  connectOrCreate: StoreCreateOrConnectWithoutPurchaseRequisitionInput
+input SupplierCreateNestedOneWithoutPurchaseOrdersInput {
+  create: SupplierCreateWithoutPurchaseOrdersInput
+  connectOrCreate: SupplierCreateOrConnectWithoutPurchaseOrdersInput
+  connect: SupplierWhereUniqueInput
+}
+
+input SupplierCreateWithoutPurchaseOrdersInput {
+  id: String
+  name: String!
+  contactInfo: JSON
+  isFrequent: Boolean
+  creditLimit: Float!
+  currentBalance: Float
+  paymentTerms: String
+  notes: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  payments: SupplierPaymentCreateNestedManyWithoutSupplierInput
+  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
+  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
+  quotes: SupplierQuoteCreateNestedManyWithoutSupplierInput
+  user: UserCreateNestedOneWithoutSupplierInput
+}
+
+input SupplierPaymentCreateNestedManyWithoutSupplierInput {
+  create: [SupplierPaymentCreateWithoutSupplierInput!]
+  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutSupplierInput!]
+  createMany: SupplierPaymentCreateManySupplierInputEnvelope
+  connect: [SupplierPaymentWhereUniqueInput!]
+}
+
+input SupplierPaymentCreateWithoutSupplierInput {
+  id: String
+  amount: Float!
+  paymentDate: DateTime!
+  method: String!
+  notes: String
+  purchaseOrder: PurchaseOrderCreateNestedOneWithoutPaymentsInput
+}
+
+input PurchaseOrderCreateNestedOneWithoutPaymentsInput {
+  create: PurchaseOrderCreateWithoutPaymentsInput
+  connectOrCreate: PurchaseOrderCreateOrConnectWithoutPaymentsInput
+  connect: PurchaseOrderWhereUniqueInput
+}
+
+input PurchaseOrderCreateWithoutPaymentsInput {
+  id: String
+  invoiceNumber: String!
+  status: PurchaseOrderStatus!
+  phase: PurchasePhase
+  dueDate: DateTime!
+  totalAmount: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
+  store: StoreCreateNestedOneWithoutPurchaseOrdersInput
+  items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
+}
+
+input PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput {
+  create: [PurchaseOrderItemCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput!]
+  createMany: PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope
+  connect: [PurchaseOrderItemWhereUniqueInput!]
+}
+
+input PurchaseOrderItemCreateWithoutPurchaseOrderInput {
+  id: String
+  quantity: Int!
+  unitCost: Float!
+  productVariant: ProductVariantCreateNestedOneWithoutPurchaseOrderItemInput!
+}
+
+input ProductVariantCreateNestedOneWithoutPurchaseOrderItemInput {
+  create: ProductVariantCreateWithoutPurchaseOrderItemInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput
+  connect: ProductVariantWhereUniqueInput
+}
+
+input ProductVariantCreateWithoutPurchaseOrderItemInput {
+  id: String
+  size: String!
+  concentration: String!
+  packaging: String!
+  barcode: String
+  price: Float!
+  resellerPrice: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  product: ProductCreateNestedOneWithoutVariantsInput!
+  stockItems: StockCreateNestedManyWithoutProductVariantInput
+  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
+  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
+  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
+  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
+  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
+  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
+  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
+  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
+  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
+  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
+  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
+}
+
+input StockMovementItemCreateNestedManyWithoutProductVariantInput {
+  create: [StockMovementItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [StockMovementItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: StockMovementItemCreateManyProductVariantInputEnvelope
+  connect: [StockMovementItemWhereUniqueInput!]
+}
+
+input StockMovementItemCreateWithoutProductVariantInput {
+  id: String
+  quantity: Int!
+  movement: StockMovementCreateNestedOneWithoutItemsInput!
+}
+
+input StockMovementCreateNestedOneWithoutItemsInput {
+  create: StockMovementCreateWithoutItemsInput
+  connectOrCreate: StockMovementCreateOrConnectWithoutItemsInput
+  connect: StockMovementWhereUniqueInput
+}
+
+input StockMovementCreateWithoutItemsInput {
+  id: String
+  direction: MovementDirection!
+  movementType: MovementType!
+  referenceEntity: String!
+  referenceId: String!
+  createdAt: DateTime
+  store: StoreCreateNestedOneWithoutMovementsInput!
+}
+
+input StoreCreateNestedOneWithoutMovementsInput {
+  create: StoreCreateWithoutMovementsInput
+  connectOrCreate: StoreCreateOrConnectWithoutMovementsInput
   connect: StoreWhereUniqueInput
 }
 
-input StoreCreateWithoutPurchaseRequisitionInput {
+input StoreCreateWithoutMovementsInput {
   id: String
   name: String!
   location: String
@@ -9513,15 +9362,28 @@ input StoreCreateWithoutPurchaseRequisitionInput {
   customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
   salesReturns: SalesReturnCreateNestedManyWithoutStoreInput
   resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
-  movements: StockMovementCreateNestedManyWithoutStoreInput
   Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
+  PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
-input StoreCreateOrConnectWithoutPurchaseRequisitionInput {
-  where: StoreWhereUniqueInput!
-  create: StoreCreateWithoutPurchaseRequisitionInput!
+input PurchaseRequisitionCreateNestedManyWithoutStoreInput {
+  create: [PurchaseRequisitionCreateWithoutStoreInput!]
+  connectOrCreate: [PurchaseRequisitionCreateOrConnectWithoutStoreInput!]
+  createMany: PurchaseRequisitionCreateManyStoreInputEnvelope
+  connect: [PurchaseRequisitionWhereUniqueInput!]
+}
+
+input PurchaseRequisitionCreateWithoutStoreInput {
+  id: String
+  status: PurchaseRequisitionStatus
+  createdAt: DateTime
+  updatedAt: DateTime
+  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
+  items: PurchaseRequisitionItemCreateNestedManyWithoutRequisitionInput
+  quotes: SupplierQuoteCreateNestedManyWithoutRequisitionInput
 }
 
 input UserCreateNestedOneWithoutPurchaseRequisitionInput {
@@ -9711,6 +9573,400 @@ input PurchaseRequisitionCreateWithoutRequestedByInput {
   quotes: SupplierQuoteCreateNestedManyWithoutRequisitionInput
 }
 
+input StoreCreateNestedOneWithoutPurchaseRequisitionInput {
+  create: StoreCreateWithoutPurchaseRequisitionInput
+  connectOrCreate: StoreCreateOrConnectWithoutPurchaseRequisitionInput
+  connect: StoreWhereUniqueInput
+}
+
+input StoreCreateWithoutPurchaseRequisitionInput {
+  id: String
+  name: String!
+  location: String
+  isMain: Boolean
+  createdAt: DateTime
+  updatedAt: DateTime
+  manager: UserCreateNestedOneWithoutStoreInput!
+  stocks: StockCreateNestedManyWithoutStoreInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutStoreInput
+  transfersOut: StockTransferCreateNestedManyWithoutFromStoreInput
+  transfersIn: StockTransferCreateNestedManyWithoutToStoreInput
+  customerSales: ConsumerSaleCreateNestedManyWithoutStoreInput
+  salesReturns: SalesReturnCreateNestedManyWithoutStoreInput
+  resellerSales: ResellerSaleCreateNestedManyWithoutStoreInput
+  movements: StockMovementCreateNestedManyWithoutStoreInput
+  Customer: CustomerCreateNestedManyWithoutPreferredStoreInput
+  CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
+  Quotation: QuotationCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
+}
+
+input PurchaseOrderCreateNestedManyWithoutStoreInput {
+  create: [PurchaseOrderCreateWithoutStoreInput!]
+  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutStoreInput!]
+  createMany: PurchaseOrderCreateManyStoreInputEnvelope
+  connect: [PurchaseOrderWhereUniqueInput!]
+}
+
+input PurchaseOrderCreateWithoutStoreInput {
+  id: String
+  invoiceNumber: String!
+  status: PurchaseOrderStatus!
+  phase: PurchasePhase
+  dueDate: DateTime!
+  totalAmount: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
+  items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
+  receipts: StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput
+  payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
+}
+
+input StockReceiptBatchCreateNestedManyWithoutPurchaseOrderInput {
+  create: [StockReceiptBatchCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput!]
+  connect: [StockReceiptBatchWhereUniqueInput!]
+}
+
+input StockReceiptBatchCreateWithoutPurchaseOrderInput {
+  id: String
+  purchaseOrderId: String!
+  waybillUrl: String
+  receivedAt: DateTime
+  store: StoreCreateNestedOneWithoutReceiptsInput!
+  receivedBy: UserCreateNestedOneWithoutStockReceiptBatchReceivedBysInput!
+  confirmedBy: UserCreateNestedOneWithoutStockReceiptBatchConfirmedBysInput!
+  items: StockReceiptBatchItemCreateNestedManyWithoutBatchInput
+  purchaseReturns: PurchaseReturnItemCreateNestedManyWithoutBatchInput
+}
+
+input PurchaseReturnItemCreateNestedManyWithoutBatchInput {
+  create: [PurchaseReturnItemCreateWithoutBatchInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutBatchInput!]
+  createMany: PurchaseReturnItemCreateManyBatchInputEnvelope
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+}
+
+input PurchaseReturnItemCreateWithoutBatchInput {
+  id: String
+  quantity: Int!
+  return: PurchaseReturnCreateNestedOneWithoutItemsInput!
+  productVariant: ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput!
+}
+
+input ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput {
+  create: ProductVariantCreateWithoutPurchaseReturnItemsInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput
+  connect: ProductVariantWhereUniqueInput
+}
+
+input ProductVariantCreateWithoutPurchaseReturnItemsInput {
+  id: String
+  size: String!
+  concentration: String!
+  packaging: String!
+  barcode: String
+  price: Float!
+  resellerPrice: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  product: ProductCreateNestedOneWithoutVariantsInput!
+  stockItems: StockCreateNestedManyWithoutProductVariantInput
+  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
+  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
+  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
+  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
+  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
+  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
+  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
+  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
+  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
+  SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
+  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
+}
+
+input PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput {
+  create: [PurchaseRequisitionItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: PurchaseRequisitionItemCreateManyProductVariantInputEnvelope
+  connect: [PurchaseRequisitionItemWhereUniqueInput!]
+}
+
+input PurchaseRequisitionItemCreateWithoutProductVariantInput {
+  id: String
+  requestedQty: Int!
+  notes: String
+  requisition: PurchaseRequisitionCreateNestedOneWithoutItemsInput!
+}
+
+input PurchaseRequisitionCreateNestedOneWithoutItemsInput {
+  create: PurchaseRequisitionCreateWithoutItemsInput
+  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutItemsInput
+  connect: PurchaseRequisitionWhereUniqueInput
+}
+
+input PurchaseRequisitionCreateWithoutItemsInput {
+  id: String
+  status: PurchaseRequisitionStatus
+  createdAt: DateTime
+  updatedAt: DateTime
+  store: StoreCreateNestedOneWithoutPurchaseRequisitionInput!
+  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
+  quotes: SupplierQuoteCreateNestedManyWithoutRequisitionInput
+}
+
+input SupplierQuoteCreateNestedManyWithoutRequisitionInput {
+  create: [SupplierQuoteCreateWithoutRequisitionInput!]
+  connectOrCreate: [SupplierQuoteCreateOrConnectWithoutRequisitionInput!]
+  createMany: SupplierQuoteCreateManyRequisitionInputEnvelope
+  connect: [SupplierQuoteWhereUniqueInput!]
+}
+
+input SupplierQuoteCreateWithoutRequisitionInput {
+  id: String
+  status: SupplierQuoteStatus
+  validUntil: DateTime
+  notes: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  supplier: SupplierCreateNestedOneWithoutQuotesInput!
+  items: SupplierQuoteItemCreateNestedManyWithoutQuoteInput
+}
+
+input SupplierCreateNestedOneWithoutQuotesInput {
+  create: SupplierCreateWithoutQuotesInput
+  connectOrCreate: SupplierCreateOrConnectWithoutQuotesInput
+  connect: SupplierWhereUniqueInput
+}
+
+input SupplierCreateWithoutQuotesInput {
+  id: String
+  name: String!
+  contactInfo: JSON
+  isFrequent: Boolean
+  creditLimit: Float!
+  currentBalance: Float
+  paymentTerms: String
+  notes: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutSupplierInput
+  payments: SupplierPaymentCreateNestedManyWithoutSupplierInput
+  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
+  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
+  user: UserCreateNestedOneWithoutSupplierInput
+}
+
+input PurchaseReturnCreateNestedManyWithoutSupplierInput {
+  create: [PurchaseReturnCreateWithoutSupplierInput!]
+  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutSupplierInput!]
+  createMany: PurchaseReturnCreateManySupplierInputEnvelope
+  connect: [PurchaseReturnWhereUniqueInput!]
+}
+
+input PurchaseReturnCreateWithoutSupplierInput {
+  id: String
+  status: ReturnStatus!
+  reason: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  initiatedBy: UserCreateNestedOneWithoutPurchaseReturnInitiatorsInput!
+  approvedBy: UserCreateNestedOneWithoutPurchaseReturnApproversInput!
+  items: PurchaseReturnItemCreateNestedManyWithoutReturnInput
+}
+
+input PurchaseReturnItemCreateNestedManyWithoutReturnInput {
+  create: [PurchaseReturnItemCreateWithoutReturnInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutReturnInput!]
+  createMany: PurchaseReturnItemCreateManyReturnInputEnvelope
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+}
+
+input PurchaseReturnItemCreateWithoutReturnInput {
+  id: String
+  quantity: Int!
+  productVariant: ProductVariantCreateNestedOneWithoutPurchaseReturnItemsInput!
+  batch: StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput!
+}
+
+input StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput {
+  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput
+  connectOrCreate: StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput
+  connect: StockReceiptBatchWhereUniqueInput
+}
+
+input StockReceiptBatchCreateWithoutPurchaseReturnsInput {
+  id: String
+  purchaseOrderId: String!
+  waybillUrl: String
+  receivedAt: DateTime
+  store: StoreCreateNestedOneWithoutReceiptsInput!
+  receivedBy: UserCreateNestedOneWithoutStockReceiptBatchReceivedBysInput!
+  confirmedBy: UserCreateNestedOneWithoutStockReceiptBatchConfirmedBysInput!
+  items: StockReceiptBatchItemCreateNestedManyWithoutBatchInput
+  PurchaseOrder: PurchaseOrderCreateNestedManyWithoutReceiptsInput
+}
+
+input PurchaseOrderCreateNestedManyWithoutReceiptsInput {
+  create: [PurchaseOrderCreateWithoutReceiptsInput!]
+  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutReceiptsInput!]
+  connect: [PurchaseOrderWhereUniqueInput!]
+}
+
+input PurchaseOrderCreateWithoutReceiptsInput {
+  id: String
+  invoiceNumber: String!
+  status: PurchaseOrderStatus!
+  phase: PurchasePhase
+  dueDate: DateTime!
+  totalAmount: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
+  store: StoreCreateNestedOneWithoutPurchaseOrdersInput
+  items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
+  payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
+}
+
+input SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput {
+  create: [SupplierPaymentCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput!]
+  createMany: SupplierPaymentCreateManyPurchaseOrderInputEnvelope
+  connect: [SupplierPaymentWhereUniqueInput!]
+}
+
+input SupplierPaymentCreateWithoutPurchaseOrderInput {
+  id: String
+  amount: Float!
+  paymentDate: DateTime!
+  method: String!
+  notes: String
+  supplier: SupplierCreateNestedOneWithoutPaymentsInput!
+}
+
+input SupplierCreateNestedOneWithoutPaymentsInput {
+  create: SupplierCreateWithoutPaymentsInput
+  connectOrCreate: SupplierCreateOrConnectWithoutPaymentsInput
+  connect: SupplierWhereUniqueInput
+}
+
+input SupplierCreateWithoutPaymentsInput {
+  id: String
+  name: String!
+  contactInfo: JSON
+  isFrequent: Boolean
+  creditLimit: Float!
+  currentBalance: Float
+  paymentTerms: String
+  notes: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutSupplierInput
+  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
+  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
+  quotes: SupplierQuoteCreateNestedManyWithoutSupplierInput
+  user: UserCreateNestedOneWithoutSupplierInput
+}
+
+input SupplierCatalogCreateNestedManyWithoutSupplierInput {
+  create: [SupplierCatalogCreateWithoutSupplierInput!]
+  connectOrCreate: [SupplierCatalogCreateOrConnectWithoutSupplierInput!]
+  createMany: SupplierCatalogCreateManySupplierInputEnvelope
+  connect: [SupplierCatalogWhereUniqueInput!]
+}
+
+input SupplierCatalogCreateWithoutSupplierInput {
+  id: String
+  defaultCost: Float!
+  leadTimeDays: Int
+  isPreferred: Boolean
+  productVariant: ProductVariantCreateNestedOneWithoutSupplierCatalogInput!
+}
+
+input ProductVariantCreateNestedOneWithoutSupplierCatalogInput {
+  create: ProductVariantCreateWithoutSupplierCatalogInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutSupplierCatalogInput
+  connect: ProductVariantWhereUniqueInput
+}
+
+input ProductVariantCreateWithoutSupplierCatalogInput {
+  id: String
+  size: String!
+  concentration: String!
+  packaging: String!
+  barcode: String
+  price: Float!
+  resellerPrice: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+  product: ProductCreateNestedOneWithoutVariantsInput!
+  stockItems: StockCreateNestedManyWithoutProductVariantInput
+  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
+  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
+  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
+  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
+  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
+  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
+  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
+  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
+  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
+  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
+  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
+}
+
+input SupplierQuoteItemCreateNestedManyWithoutProductVariantInput {
+  create: [SupplierQuoteItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutProductVariantInput!]
+  createMany: SupplierQuoteItemCreateManyProductVariantInputEnvelope
+  connect: [SupplierQuoteItemWhereUniqueInput!]
+}
+
+input SupplierQuoteItemCreateWithoutProductVariantInput {
+  id: String
+  unitCost: Float!
+  minQty: Int
+  leadTimeDays: Int
+  quote: SupplierQuoteCreateNestedOneWithoutItemsInput!
+}
+
+input SupplierQuoteCreateNestedOneWithoutItemsInput {
+  create: SupplierQuoteCreateWithoutItemsInput
+  connectOrCreate: SupplierQuoteCreateOrConnectWithoutItemsInput
+  connect: SupplierQuoteWhereUniqueInput
+}
+
+input SupplierQuoteCreateWithoutItemsInput {
+  id: String
+  status: SupplierQuoteStatus
+  validUntil: DateTime
+  notes: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  requisition: PurchaseRequisitionCreateNestedOneWithoutQuotesInput!
+  supplier: SupplierCreateNestedOneWithoutQuotesInput!
+}
+
+input PurchaseRequisitionCreateNestedOneWithoutQuotesInput {
+  create: PurchaseRequisitionCreateWithoutQuotesInput
+  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutQuotesInput
+  connect: PurchaseRequisitionWhereUniqueInput
+}
+
+input PurchaseRequisitionCreateWithoutQuotesInput {
+  id: String
+  status: PurchaseRequisitionStatus
+  createdAt: DateTime
+  updatedAt: DateTime
+  store: StoreCreateNestedOneWithoutPurchaseRequisitionInput!
+  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
+  items: PurchaseRequisitionItemCreateNestedManyWithoutRequisitionInput
+}
+
 input PurchaseRequisitionItemCreateNestedManyWithoutRequisitionInput {
   create: [PurchaseRequisitionItemCreateWithoutRequisitionInput!]
   connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutRequisitionInput!]
@@ -9755,6 +10011,7 @@ input ProductVariantCreateWithoutPurchaseRequisitionItemInput {
   StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input SupplierCatalogCreateNestedManyWithoutProductVariantInput {
@@ -9814,43 +10071,6 @@ input SupplierQuoteCreateWithoutSupplierInput {
   items: SupplierQuoteItemCreateNestedManyWithoutQuoteInput
 }
 
-input PurchaseRequisitionCreateNestedOneWithoutQuotesInput {
-  create: PurchaseRequisitionCreateWithoutQuotesInput
-  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutQuotesInput
-  connect: PurchaseRequisitionWhereUniqueInput
-}
-
-input PurchaseRequisitionCreateWithoutQuotesInput {
-  id: String
-  status: PurchaseRequisitionStatus
-  createdAt: DateTime
-  updatedAt: DateTime
-  store: StoreCreateNestedOneWithoutPurchaseRequisitionInput!
-  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
-  items: PurchaseRequisitionItemCreateNestedManyWithoutRequisitionInput
-}
-
-input PurchaseRequisitionCreateOrConnectWithoutQuotesInput {
-  where: PurchaseRequisitionWhereUniqueInput!
-  create: PurchaseRequisitionCreateWithoutQuotesInput!
-}
-
-input PurchaseRequisitionWhereUniqueInput {
-  id: String
-  AND: [PurchaseRequisitionWhereInput!]
-  OR: [PurchaseRequisitionWhereInput!]
-  NOT: [PurchaseRequisitionWhereInput!]
-  storeId: StringFilter
-  requestedById: StringFilter
-  status: EnumPurchaseRequisitionStatusFilter
-  createdAt: DateTimeFilter
-  updatedAt: DateTimeFilter
-  store: StoreScalarRelationFilter
-  requestedBy: UserScalarRelationFilter
-  items: PurchaseRequisitionItemListRelationFilter
-  quotes: SupplierQuoteListRelationFilter
-}
-
 input SupplierQuoteItemCreateNestedManyWithoutQuoteInput {
   create: [SupplierQuoteItemCreateWithoutQuoteInput!]
   connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutQuoteInput!]
@@ -9896,6 +10116,53 @@ input ProductVariantCreateWithoutSupplierQuoteItemInput {
   StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
+}
+
+input ProductVariantTierPriceCreateNestedManyWithoutVariantInput {
+  create: [ProductVariantTierPriceCreateWithoutVariantInput!]
+  connectOrCreate: [ProductVariantTierPriceCreateOrConnectWithoutVariantInput!]
+  createMany: ProductVariantTierPriceCreateManyVariantInputEnvelope
+  connect: [ProductVariantTierPriceWhereUniqueInput!]
+}
+
+input ProductVariantTierPriceCreateWithoutVariantInput {
+  id: String
+  tier: UserTier!
+  price: Float!
+}
+
+input ProductVariantTierPriceCreateOrConnectWithoutVariantInput {
+  where: ProductVariantTierPriceWhereUniqueInput!
+  create: ProductVariantTierPriceCreateWithoutVariantInput!
+}
+
+input ProductVariantTierPriceWhereUniqueInput {
+  id: String
+  productVariantId_tier: ProductVariantTierPriceProductVariantIdTierCompoundUniqueInput
+  AND: [ProductVariantTierPriceWhereInput!]
+  OR: [ProductVariantTierPriceWhereInput!]
+  NOT: [ProductVariantTierPriceWhereInput!]
+  productVariantId: StringFilter
+  tier: EnumUserTierFilter
+  price: FloatFilter
+  variant: ProductVariantScalarRelationFilter
+}
+
+input ProductVariantTierPriceProductVariantIdTierCompoundUniqueInput {
+  productVariantId: String!
+  tier: UserTier!
+}
+
+input ProductVariantTierPriceCreateManyVariantInputEnvelope {
+  data: [ProductVariantTierPriceCreateManyVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input ProductVariantTierPriceCreateManyVariantInput {
+  id: String
+  tier: UserTier!
+  price: Float!
 }
 
 input ProductVariantCreateOrConnectWithoutSupplierQuoteItemInput {
@@ -10101,160 +10368,6 @@ input SupplierCatalogCreateManyProductVariantInput {
   isPreferred: Boolean
 }
 
-input SupplierQuoteItemCreateNestedManyWithoutProductVariantInput {
-  create: [SupplierQuoteItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutProductVariantInput!]
-  createMany: SupplierQuoteItemCreateManyProductVariantInputEnvelope
-  connect: [SupplierQuoteItemWhereUniqueInput!]
-}
-
-input SupplierQuoteItemCreateWithoutProductVariantInput {
-  id: String
-  unitCost: Float!
-  minQty: Int
-  leadTimeDays: Int
-  quote: SupplierQuoteCreateNestedOneWithoutItemsInput!
-}
-
-input SupplierQuoteCreateNestedOneWithoutItemsInput {
-  create: SupplierQuoteCreateWithoutItemsInput
-  connectOrCreate: SupplierQuoteCreateOrConnectWithoutItemsInput
-  connect: SupplierQuoteWhereUniqueInput
-}
-
-input SupplierQuoteCreateWithoutItemsInput {
-  id: String
-  status: SupplierQuoteStatus
-  validUntil: DateTime
-  notes: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  requisition: PurchaseRequisitionCreateNestedOneWithoutQuotesInput!
-  supplier: SupplierCreateNestedOneWithoutQuotesInput!
-}
-
-input SupplierCreateNestedOneWithoutQuotesInput {
-  create: SupplierCreateWithoutQuotesInput
-  connectOrCreate: SupplierCreateOrConnectWithoutQuotesInput
-  connect: SupplierWhereUniqueInput
-}
-
-input SupplierCreateWithoutQuotesInput {
-  id: String
-  name: String!
-  contactInfo: JSON
-  isFrequent: Boolean
-  creditLimit: Float!
-  currentBalance: Float
-  paymentTerms: String
-  notes: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  purchaseOrders: PurchaseOrderCreateNestedManyWithoutSupplierInput
-  payments: SupplierPaymentCreateNestedManyWithoutSupplierInput
-  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
-  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
-  user: UserCreateNestedOneWithoutSupplierInput
-}
-
-input SupplierCatalogCreateNestedManyWithoutSupplierInput {
-  create: [SupplierCatalogCreateWithoutSupplierInput!]
-  connectOrCreate: [SupplierCatalogCreateOrConnectWithoutSupplierInput!]
-  createMany: SupplierCatalogCreateManySupplierInputEnvelope
-  connect: [SupplierCatalogWhereUniqueInput!]
-}
-
-input SupplierCatalogCreateWithoutSupplierInput {
-  id: String
-  defaultCost: Float!
-  leadTimeDays: Int
-  isPreferred: Boolean
-  productVariant: ProductVariantCreateNestedOneWithoutSupplierCatalogInput!
-}
-
-input ProductVariantCreateNestedOneWithoutSupplierCatalogInput {
-  create: ProductVariantCreateWithoutSupplierCatalogInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutSupplierCatalogInput
-  connect: ProductVariantWhereUniqueInput
-}
-
-input ProductVariantCreateWithoutSupplierCatalogInput {
-  id: String
-  size: String!
-  concentration: String!
-  packaging: String!
-  barcode: String
-  price: Float!
-  resellerPrice: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  product: ProductCreateNestedOneWithoutVariantsInput!
-  stockItems: StockCreateNestedManyWithoutProductVariantInput
-  receiptItems: StockReceiptBatchItemCreateNestedManyWithoutProductVariantInput
-  quotationItems: QuotationItemCreateNestedManyWithoutProductVariantInput
-  resellerItems: ResellerSaleItemCreateNestedManyWithoutProductVariantInput
-  consumerItems: ConsumerSaleItemCreateNestedManyWithoutProductVariantInput
-  returnItems: SalesReturnItemCreateNestedManyWithoutProductVariantInput
-  purchaseReturnItems: PurchaseReturnItemCreateNestedManyWithoutProductVariantInput
-  transferItems: StockTransferItemCreateNestedManyWithoutProductVariantInput
-  stats: ProductSalesStatsCreateNestedOneWithoutProductVariantInput
-  PurchaseOrderItem: PurchaseOrderItemCreateNestedManyWithoutProductVariantInput
-  StockMovementItem: StockMovementItemCreateNestedManyWithoutProductVariantInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
-  SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
-}
-
-input ProductVariantCreateOrConnectWithoutSupplierCatalogInput {
-  where: ProductVariantWhereUniqueInput!
-  create: ProductVariantCreateWithoutSupplierCatalogInput!
-}
-
-input SupplierCatalogCreateOrConnectWithoutSupplierInput {
-  where: SupplierCatalogWhereUniqueInput!
-  create: SupplierCatalogCreateWithoutSupplierInput!
-}
-
-input SupplierCatalogCreateManySupplierInputEnvelope {
-  data: [SupplierCatalogCreateManySupplierInput!]!
-  skipDuplicates: Boolean
-}
-
-input SupplierCatalogCreateManySupplierInput {
-  id: String
-  productVariantId: String!
-  defaultCost: Float!
-  leadTimeDays: Int
-  isPreferred: Boolean
-}
-
-input SupplierCreateOrConnectWithoutQuotesInput {
-  where: SupplierWhereUniqueInput!
-  create: SupplierCreateWithoutQuotesInput!
-}
-
-input SupplierQuoteCreateOrConnectWithoutItemsInput {
-  where: SupplierQuoteWhereUniqueInput!
-  create: SupplierQuoteCreateWithoutItemsInput!
-}
-
-input SupplierQuoteItemCreateOrConnectWithoutProductVariantInput {
-  where: SupplierQuoteItemWhereUniqueInput!
-  create: SupplierQuoteItemCreateWithoutProductVariantInput!
-}
-
-input SupplierQuoteItemCreateManyProductVariantInputEnvelope {
-  data: [SupplierQuoteItemCreateManyProductVariantInput!]!
-  skipDuplicates: Boolean
-}
-
-input SupplierQuoteItemCreateManyProductVariantInput {
-  id: String
-  quoteId: String!
-  unitCost: Float!
-  minQty: Int
-  leadTimeDays: Int
-}
-
 input ProductVariantCreateOrConnectWithoutPurchaseRequisitionItemInput {
   where: ProductVariantWhereUniqueInput!
   create: ProductVariantCreateWithoutPurchaseRequisitionItemInput!
@@ -10290,22 +10403,234 @@ input PurchaseRequisitionItemCreateManyRequisitionInput {
   notes: String
 }
 
-input SupplierQuoteCreateNestedManyWithoutRequisitionInput {
-  create: [SupplierQuoteCreateWithoutRequisitionInput!]
-  connectOrCreate: [SupplierQuoteCreateOrConnectWithoutRequisitionInput!]
-  createMany: SupplierQuoteCreateManyRequisitionInputEnvelope
-  connect: [SupplierQuoteWhereUniqueInput!]
+input PurchaseRequisitionCreateOrConnectWithoutQuotesInput {
+  where: PurchaseRequisitionWhereUniqueInput!
+  create: PurchaseRequisitionCreateWithoutQuotesInput!
 }
 
-input SupplierQuoteCreateWithoutRequisitionInput {
+input PurchaseRequisitionWhereUniqueInput {
   id: String
-  status: SupplierQuoteStatus
-  validUntil: DateTime
+  AND: [PurchaseRequisitionWhereInput!]
+  OR: [PurchaseRequisitionWhereInput!]
+  NOT: [PurchaseRequisitionWhereInput!]
+  storeId: StringFilter
+  requestedById: StringFilter
+  status: EnumPurchaseRequisitionStatusFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  store: StoreScalarRelationFilter
+  requestedBy: UserScalarRelationFilter
+  items: PurchaseRequisitionItemListRelationFilter
+  quotes: SupplierQuoteListRelationFilter
+}
+
+input SupplierQuoteCreateOrConnectWithoutItemsInput {
+  where: SupplierQuoteWhereUniqueInput!
+  create: SupplierQuoteCreateWithoutItemsInput!
+}
+
+input SupplierQuoteItemCreateOrConnectWithoutProductVariantInput {
+  where: SupplierQuoteItemWhereUniqueInput!
+  create: SupplierQuoteItemCreateWithoutProductVariantInput!
+}
+
+input SupplierQuoteItemCreateManyProductVariantInputEnvelope {
+  data: [SupplierQuoteItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input SupplierQuoteItemCreateManyProductVariantInput {
+  id: String
+  quoteId: String!
+  unitCost: Float!
+  minQty: Int
+  leadTimeDays: Int
+}
+
+input ProductVariantCreateOrConnectWithoutSupplierCatalogInput {
+  where: ProductVariantWhereUniqueInput!
+  create: ProductVariantCreateWithoutSupplierCatalogInput!
+}
+
+input SupplierCatalogCreateOrConnectWithoutSupplierInput {
+  where: SupplierCatalogWhereUniqueInput!
+  create: SupplierCatalogCreateWithoutSupplierInput!
+}
+
+input SupplierCatalogCreateManySupplierInputEnvelope {
+  data: [SupplierCatalogCreateManySupplierInput!]!
+  skipDuplicates: Boolean
+}
+
+input SupplierCatalogCreateManySupplierInput {
+  id: String
+  productVariantId: String!
+  defaultCost: Float!
+  leadTimeDays: Int
+  isPreferred: Boolean
+}
+
+input SupplierCreateOrConnectWithoutPaymentsInput {
+  where: SupplierWhereUniqueInput!
+  create: SupplierCreateWithoutPaymentsInput!
+}
+
+input SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput {
+  where: SupplierPaymentWhereUniqueInput!
+  create: SupplierPaymentCreateWithoutPurchaseOrderInput!
+}
+
+input SupplierPaymentWhereUniqueInput {
+  id: String
+  AND: [SupplierPaymentWhereInput!]
+  OR: [SupplierPaymentWhereInput!]
+  NOT: [SupplierPaymentWhereInput!]
+  supplierId: StringFilter
+  purchaseOrderId: StringNullableFilter
+  amount: FloatFilter
+  paymentDate: DateTimeFilter
+  method: StringFilter
+  notes: StringNullableFilter
+  supplier: SupplierScalarRelationFilter
+  purchaseOrder: PurchaseOrderNullableScalarRelationFilter
+}
+
+input SupplierPaymentCreateManyPurchaseOrderInputEnvelope {
+  data: [SupplierPaymentCreateManyPurchaseOrderInput!]!
+  skipDuplicates: Boolean
+}
+
+input SupplierPaymentCreateManyPurchaseOrderInput {
+  id: String
+  supplierId: String!
+  amount: Float!
+  paymentDate: DateTime!
+  method: String!
   notes: String
+}
+
+input PurchaseOrderCreateOrConnectWithoutReceiptsInput {
+  where: PurchaseOrderWhereUniqueInput!
+  create: PurchaseOrderCreateWithoutReceiptsInput!
+}
+
+input PurchaseOrderWhereUniqueInput {
+  id: String
+  AND: [PurchaseOrderWhereInput!]
+  OR: [PurchaseOrderWhereInput!]
+  NOT: [PurchaseOrderWhereInput!]
+  supplierId: StringFilter
+  storeId: StringNullableFilter
+  invoiceNumber: StringFilter
+  status: EnumPurchaseOrderStatusFilter
+  phase: EnumPurchasePhaseFilter
+  dueDate: DateTimeFilter
+  totalAmount: FloatFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  supplier: SupplierScalarRelationFilter
+  store: StoreNullableScalarRelationFilter
+  items: PurchaseOrderItemListRelationFilter
+  receipts: StockReceiptBatchListRelationFilter
+  payments: SupplierPaymentListRelationFilter
+}
+
+input StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput {
+  where: StockReceiptBatchWhereUniqueInput!
+  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput!
+}
+
+input StockReceiptBatchWhereUniqueInput {
+  id: String
+  AND: [StockReceiptBatchWhereInput!]
+  OR: [StockReceiptBatchWhereInput!]
+  NOT: [StockReceiptBatchWhereInput!]
+  purchaseOrderId: StringFilter
+  storeId: StringFilter
+  receivedById: StringFilter
+  confirmedById: StringFilter
+  waybillUrl: StringNullableFilter
+  receivedAt: DateTimeFilter
+  store: StoreScalarRelationFilter
+  receivedBy: UserScalarRelationFilter
+  confirmedBy: UserScalarRelationFilter
+  items: StockReceiptBatchItemListRelationFilter
+  purchaseReturns: PurchaseReturnItemListRelationFilter
+  PurchaseOrder: PurchaseOrderListRelationFilter
+}
+
+input PurchaseReturnItemCreateOrConnectWithoutReturnInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  create: PurchaseReturnItemCreateWithoutReturnInput!
+}
+
+input PurchaseReturnItemWhereUniqueInput {
+  id: String
+  AND: [PurchaseReturnItemWhereInput!]
+  OR: [PurchaseReturnItemWhereInput!]
+  NOT: [PurchaseReturnItemWhereInput!]
+  purchaseReturnId: StringFilter
+  productVariantId: StringFilter
+  batchId: StringFilter
+  quantity: IntFilter
+  return: PurchaseReturnScalarRelationFilter
+  productVariant: ProductVariantScalarRelationFilter
+  batch: StockReceiptBatchScalarRelationFilter
+}
+
+input PurchaseReturnItemCreateManyReturnInputEnvelope {
+  data: [PurchaseReturnItemCreateManyReturnInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseReturnItemCreateManyReturnInput {
+  id: String
+  productVariantId: String!
+  batchId: String!
+  quantity: Int!
+}
+
+input PurchaseReturnCreateOrConnectWithoutSupplierInput {
+  where: PurchaseReturnWhereUniqueInput!
+  create: PurchaseReturnCreateWithoutSupplierInput!
+}
+
+input PurchaseReturnWhereUniqueInput {
+  id: String
+  AND: [PurchaseReturnWhereInput!]
+  OR: [PurchaseReturnWhereInput!]
+  NOT: [PurchaseReturnWhereInput!]
+  supplierId: StringFilter
+  initiatedById: StringFilter
+  approvedById: StringFilter
+  status: EnumReturnStatusFilter
+  reason: StringNullableFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+  supplier: SupplierScalarRelationFilter
+  initiatedBy: UserScalarRelationFilter
+  approvedBy: UserScalarRelationFilter
+  items: PurchaseReturnItemListRelationFilter
+}
+
+input PurchaseReturnCreateManySupplierInputEnvelope {
+  data: [PurchaseReturnCreateManySupplierInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseReturnCreateManySupplierInput {
+  id: String
+  initiatedById: String!
+  approvedById: String!
+  status: ReturnStatus!
+  reason: String
   createdAt: DateTime
   updatedAt: DateTime
-  supplier: SupplierCreateNestedOneWithoutQuotesInput!
-  items: SupplierQuoteItemCreateNestedManyWithoutQuoteInput
+}
+
+input SupplierCreateOrConnectWithoutQuotesInput {
+  where: SupplierWhereUniqueInput!
+  create: SupplierCreateWithoutQuotesInput!
 }
 
 input SupplierQuoteCreateOrConnectWithoutRequisitionInput {
@@ -10326,6 +10651,82 @@ input SupplierQuoteCreateManyRequisitionInput {
   notes: String
   createdAt: DateTime
   updatedAt: DateTime
+}
+
+input PurchaseRequisitionCreateOrConnectWithoutItemsInput {
+  where: PurchaseRequisitionWhereUniqueInput!
+  create: PurchaseRequisitionCreateWithoutItemsInput!
+}
+
+input PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput {
+  where: PurchaseRequisitionItemWhereUniqueInput!
+  create: PurchaseRequisitionItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseRequisitionItemCreateManyProductVariantInputEnvelope {
+  data: [PurchaseRequisitionItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseRequisitionItemCreateManyProductVariantInput {
+  id: String
+  requisitionId: String!
+  requestedQty: Int!
+  notes: String
+}
+
+input ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput {
+  where: ProductVariantWhereUniqueInput!
+  create: ProductVariantCreateWithoutPurchaseReturnItemsInput!
+}
+
+input PurchaseReturnItemCreateOrConnectWithoutBatchInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  create: PurchaseReturnItemCreateWithoutBatchInput!
+}
+
+input PurchaseReturnItemCreateManyBatchInputEnvelope {
+  data: [PurchaseReturnItemCreateManyBatchInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseReturnItemCreateManyBatchInput {
+  id: String
+  purchaseReturnId: String!
+  productVariantId: String!
+  quantity: Int!
+}
+
+input StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput {
+  where: StockReceiptBatchWhereUniqueInput!
+  create: StockReceiptBatchCreateWithoutPurchaseOrderInput!
+}
+
+input PurchaseOrderCreateOrConnectWithoutStoreInput {
+  where: PurchaseOrderWhereUniqueInput!
+  create: PurchaseOrderCreateWithoutStoreInput!
+}
+
+input PurchaseOrderCreateManyStoreInputEnvelope {
+  data: [PurchaseOrderCreateManyStoreInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseOrderCreateManyStoreInput {
+  id: String
+  supplierId: String!
+  invoiceNumber: String!
+  status: PurchaseOrderStatus!
+  phase: PurchasePhase
+  dueDate: DateTime!
+  totalAmount: Float!
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input StoreCreateOrConnectWithoutPurchaseRequisitionInput {
+  where: StoreWhereUniqueInput!
+  create: StoreCreateWithoutPurchaseRequisitionInput!
 }
 
 input PurchaseRequisitionCreateOrConnectWithoutRequestedByInput {
@@ -11070,26 +11471,161 @@ input UserCreateOrConnectWithoutPurchaseRequisitionInput {
   create: UserCreateWithoutPurchaseRequisitionInput!
 }
 
-input PurchaseRequisitionCreateOrConnectWithoutItemsInput {
+input PurchaseRequisitionCreateOrConnectWithoutStoreInput {
   where: PurchaseRequisitionWhereUniqueInput!
-  create: PurchaseRequisitionCreateWithoutItemsInput!
+  create: PurchaseRequisitionCreateWithoutStoreInput!
 }
 
-input PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput {
-  where: PurchaseRequisitionItemWhereUniqueInput!
-  create: PurchaseRequisitionItemCreateWithoutProductVariantInput!
-}
-
-input PurchaseRequisitionItemCreateManyProductVariantInputEnvelope {
-  data: [PurchaseRequisitionItemCreateManyProductVariantInput!]!
+input PurchaseRequisitionCreateManyStoreInputEnvelope {
+  data: [PurchaseRequisitionCreateManyStoreInput!]!
   skipDuplicates: Boolean
 }
 
-input PurchaseRequisitionItemCreateManyProductVariantInput {
+input PurchaseRequisitionCreateManyStoreInput {
   id: String
-  requisitionId: String!
-  requestedQty: Int!
+  requestedById: String!
+  status: PurchaseRequisitionStatus
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input StoreCreateOrConnectWithoutMovementsInput {
+  where: StoreWhereUniqueInput!
+  create: StoreCreateWithoutMovementsInput!
+}
+
+input StockMovementCreateOrConnectWithoutItemsInput {
+  where: StockMovementWhereUniqueInput!
+  create: StockMovementCreateWithoutItemsInput!
+}
+
+input StockMovementWhereUniqueInput {
+  id: String
+  AND: [StockMovementWhereInput!]
+  OR: [StockMovementWhereInput!]
+  NOT: [StockMovementWhereInput!]
+  storeId: StringFilter
+  direction: EnumMovementDirectionFilter
+  movementType: EnumMovementTypeFilter
+  referenceEntity: StringFilter
+  referenceId: StringFilter
+  createdAt: DateTimeFilter
+  store: StoreScalarRelationFilter
+  items: StockMovementItemListRelationFilter
+}
+
+input StockMovementItemCreateOrConnectWithoutProductVariantInput {
+  where: StockMovementItemWhereUniqueInput!
+  create: StockMovementItemCreateWithoutProductVariantInput!
+}
+
+input StockMovementItemWhereUniqueInput {
+  id: String
+  AND: [StockMovementItemWhereInput!]
+  OR: [StockMovementItemWhereInput!]
+  NOT: [StockMovementItemWhereInput!]
+  stockMovementId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  movement: StockMovementScalarRelationFilter
+  productVariant: ProductVariantScalarRelationFilter
+}
+
+input StockMovementItemCreateManyProductVariantInputEnvelope {
+  data: [StockMovementItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input StockMovementItemCreateManyProductVariantInput {
+  id: String
+  stockMovementId: String!
+  quantity: Int!
+}
+
+input ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput {
+  where: ProductVariantWhereUniqueInput!
+  create: ProductVariantCreateWithoutPurchaseOrderItemInput!
+}
+
+input PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  create: PurchaseOrderItemCreateWithoutPurchaseOrderInput!
+}
+
+input PurchaseOrderItemWhereUniqueInput {
+  id: String
+  AND: [PurchaseOrderItemWhereInput!]
+  OR: [PurchaseOrderItemWhereInput!]
+  NOT: [PurchaseOrderItemWhereInput!]
+  purchaseOrderId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  unitCost: FloatFilter
+  purchaseOrder: PurchaseOrderScalarRelationFilter
+  productVariant: ProductVariantScalarRelationFilter
+}
+
+input PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope {
+  data: [PurchaseOrderItemCreateManyPurchaseOrderInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseOrderItemCreateManyPurchaseOrderInput {
+  id: String
+  productVariantId: String!
+  quantity: Int!
+  unitCost: Float!
+}
+
+input PurchaseOrderCreateOrConnectWithoutPaymentsInput {
+  where: PurchaseOrderWhereUniqueInput!
+  create: PurchaseOrderCreateWithoutPaymentsInput!
+}
+
+input SupplierPaymentCreateOrConnectWithoutSupplierInput {
+  where: SupplierPaymentWhereUniqueInput!
+  create: SupplierPaymentCreateWithoutSupplierInput!
+}
+
+input SupplierPaymentCreateManySupplierInputEnvelope {
+  data: [SupplierPaymentCreateManySupplierInput!]!
+  skipDuplicates: Boolean
+}
+
+input SupplierPaymentCreateManySupplierInput {
+  id: String
+  purchaseOrderId: String
+  amount: Float!
+  paymentDate: DateTime!
+  method: String!
   notes: String
+}
+
+input SupplierCreateOrConnectWithoutPurchaseOrdersInput {
+  where: SupplierWhereUniqueInput!
+  create: SupplierCreateWithoutPurchaseOrdersInput!
+}
+
+input PurchaseOrderCreateOrConnectWithoutItemsInput {
+  where: PurchaseOrderWhereUniqueInput!
+  create: PurchaseOrderCreateWithoutItemsInput!
+}
+
+input PurchaseOrderItemCreateOrConnectWithoutProductVariantInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  create: PurchaseOrderItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseOrderItemCreateManyProductVariantInputEnvelope {
+  data: [PurchaseOrderItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseOrderItemCreateManyProductVariantInput {
+  id: String
+  purchaseOrderId: String!
+  quantity: Int!
+  unitCost: Float!
 }
 
 input ProductVariantCreateOrConnectWithoutReturnItemsInput {
@@ -11183,6 +11719,214 @@ input ResellerSaleCreateOrConnectWithoutQuotationInput {
   create: ResellerSaleCreateWithoutQuotationInput!
 }
 
+input QuotationCreateOrConnectWithoutBillerInput {
+  where: QuotationWhereUniqueInput!
+  create: QuotationCreateWithoutBillerInput!
+}
+
+input QuotationCreateManyBillerInputEnvelope {
+  data: [QuotationCreateManyBillerInput!]!
+  skipDuplicates: Boolean
+}
+
+input QuotationCreateManyBillerInput {
+  id: String
+  type: SaleType!
+  channel: SaleChannel!
+  storeId: String!
+  consumerId: String
+  resellerId: String
+  status: QuotationStatus
+  totalAmount: Float!
+  saleOrderId: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input UserCreateOrConnectWithoutResellerTierHistoryInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutResellerTierHistoryInput!
+}
+
+input ResellerTierHistoryCreateOrConnectWithoutAdminInput {
+  where: ResellerTierHistoryWhereUniqueInput!
+  create: ResellerTierHistoryCreateWithoutAdminInput!
+}
+
+input ResellerTierHistoryWhereUniqueInput {
+  id: String
+  AND: [ResellerTierHistoryWhereInput!]
+  OR: [ResellerTierHistoryWhereInput!]
+  NOT: [ResellerTierHistoryWhereInput!]
+  userId: StringFilter
+  fromTier: EnumUserTierFilter
+  toTier: EnumUserTierFilter
+  changedBy: StringFilter
+  changedAt: DateTimeFilter
+  user: UserScalarRelationFilter
+  admin: UserScalarRelationFilter
+}
+
+input ResellerTierHistoryCreateManyAdminInputEnvelope {
+  data: [ResellerTierHistoryCreateManyAdminInput!]!
+  skipDuplicates: Boolean
+}
+
+input ResellerTierHistoryCreateManyAdminInput {
+  id: String
+  userId: String!
+  fromTier: UserTier!
+  toTier: UserTier!
+  changedAt: DateTime
+}
+
+input UserCreateOrConnectWithoutPurchaseReturnApproversInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutPurchaseReturnApproversInput!
+}
+
+input PurchaseReturnCreateOrConnectWithoutItemsInput {
+  where: PurchaseReturnWhereUniqueInput!
+  create: PurchaseReturnCreateWithoutItemsInput!
+}
+
+input PurchaseReturnItemCreateOrConnectWithoutProductVariantInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  create: PurchaseReturnItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseReturnItemCreateManyProductVariantInputEnvelope {
+  data: [PurchaseReturnItemCreateManyProductVariantInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseReturnItemCreateManyProductVariantInput {
+  id: String
+  purchaseReturnId: String!
+  batchId: String!
+  quantity: Int!
+}
+
+input ProductVariantCreateOrConnectWithoutQuotationItemsInput {
+  where: ProductVariantWhereUniqueInput!
+  create: ProductVariantCreateWithoutQuotationItemsInput!
+}
+
+input QuotationItemCreateOrConnectWithoutQuotationInput {
+  where: QuotationItemWhereUniqueInput!
+  create: QuotationItemCreateWithoutQuotationInput!
+}
+
+input QuotationItemWhereUniqueInput {
+  id: String
+  AND: [QuotationItemWhereInput!]
+  OR: [QuotationItemWhereInput!]
+  NOT: [QuotationItemWhereInput!]
+  quotationId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  unitPrice: FloatFilter
+  quotation: QuotationScalarRelationFilter
+  productVariant: ProductVariantScalarRelationFilter
+}
+
+input QuotationItemCreateManyQuotationInputEnvelope {
+  data: [QuotationItemCreateManyQuotationInput!]!
+  skipDuplicates: Boolean
+}
+
+input QuotationItemCreateManyQuotationInput {
+  id: String
+  productVariantId: String!
+  quantity: Int!
+  unitPrice: Float!
+}
+
+input QuotationCreateOrConnectWithoutSaleOrderInput {
+  where: QuotationWhereUniqueInput!
+  create: QuotationCreateWithoutSaleOrderInput!
+}
+
+input SaleOrderCreateOrConnectWithoutFulfillmentInput {
+  where: SaleOrderWhereUniqueInput!
+  create: SaleOrderCreateWithoutFulfillmentInput!
+}
+
+input FulfillmentCreateOrConnectWithoutDeliveryPersonnelInput {
+  where: FulfillmentWhereUniqueInput!
+  create: FulfillmentCreateWithoutDeliveryPersonnelInput!
+}
+
+input FulfillmentCreateManyDeliveryPersonnelInputEnvelope {
+  data: [FulfillmentCreateManyDeliveryPersonnelInput!]!
+  skipDuplicates: Boolean
+}
+
+input FulfillmentCreateManyDeliveryPersonnelInput {
+  id: String
+  saleOrderId: String!
+  type: FulfillmentType!
+  deliveryAddress: String
+  status: FulfillmentStatus
+  cost: Float
+  confirmationPin: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input UserCreateOrConnectWithoutResellerTierHistoryChangedBysInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutResellerTierHistoryChangedBysInput!
+}
+
+input ResellerTierHistoryCreateOrConnectWithoutUserInput {
+  where: ResellerTierHistoryWhereUniqueInput!
+  create: ResellerTierHistoryCreateWithoutUserInput!
+}
+
+input ResellerTierHistoryCreateManyUserInputEnvelope {
+  data: [ResellerTierHistoryCreateManyUserInput!]!
+  skipDuplicates: Boolean
+}
+
+input ResellerTierHistoryCreateManyUserInput {
+  id: String
+  fromTier: UserTier!
+  toTier: UserTier!
+  changedBy: String!
+  changedAt: DateTime
+}
+
+input UserCreateOrConnectWithoutPurchaseReturnInitiatorsInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutPurchaseReturnInitiatorsInput!
+}
+
+input PurchaseReturnCreateOrConnectWithoutApprovedByInput {
+  where: PurchaseReturnWhereUniqueInput!
+  create: PurchaseReturnCreateWithoutApprovedByInput!
+}
+
+input PurchaseReturnCreateManyApprovedByInputEnvelope {
+  data: [PurchaseReturnCreateManyApprovedByInput!]!
+  skipDuplicates: Boolean
+}
+
+input PurchaseReturnCreateManyApprovedByInput {
+  id: String
+  supplierId: String!
+  initiatedById: String!
+  status: ReturnStatus!
+  reason: String
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+
+input UserCreateOrConnectWithoutResellerQuotationInput {
+  where: UserWhereUniqueInput!
+  create: UserCreateWithoutResellerQuotationInput!
+}
+
 input QuotationCreateOrConnectWithoutStoreInput {
   where: QuotationWhereUniqueInput!
   create: QuotationCreateWithoutStoreInput!
@@ -11203,41 +11947,6 @@ input QuotationCreateManyStoreInput {
   status: QuotationStatus
   totalAmount: Float!
   saleOrderId: String
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input PurchaseRequisitionCreateNestedManyWithoutStoreInput {
-  create: [PurchaseRequisitionCreateWithoutStoreInput!]
-  connectOrCreate: [PurchaseRequisitionCreateOrConnectWithoutStoreInput!]
-  createMany: PurchaseRequisitionCreateManyStoreInputEnvelope
-  connect: [PurchaseRequisitionWhereUniqueInput!]
-}
-
-input PurchaseRequisitionCreateWithoutStoreInput {
-  id: String
-  status: PurchaseRequisitionStatus
-  createdAt: DateTime
-  updatedAt: DateTime
-  requestedBy: UserCreateNestedOneWithoutPurchaseRequisitionInput!
-  items: PurchaseRequisitionItemCreateNestedManyWithoutRequisitionInput
-  quotes: SupplierQuoteCreateNestedManyWithoutRequisitionInput
-}
-
-input PurchaseRequisitionCreateOrConnectWithoutStoreInput {
-  where: PurchaseRequisitionWhereUniqueInput!
-  create: PurchaseRequisitionCreateWithoutStoreInput!
-}
-
-input PurchaseRequisitionCreateManyStoreInputEnvelope {
-  data: [PurchaseRequisitionCreateManyStoreInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseRequisitionCreateManyStoreInput {
-  id: String
-  requestedById: String!
-  status: PurchaseRequisitionStatus
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -11309,499 +12018,9 @@ input CustomerProfileCreateManyPreferredStoreInput {
   phoneVerificationCodeExpiry: DateTime
 }
 
-input StoreCreateOrConnectWithoutMovementsInput {
+input StoreCreateOrConnectWithoutPurchaseOrdersInput {
   where: StoreWhereUniqueInput!
-  create: StoreCreateWithoutMovementsInput!
-}
-
-input StockMovementCreateOrConnectWithoutItemsInput {
-  where: StockMovementWhereUniqueInput!
-  create: StockMovementCreateWithoutItemsInput!
-}
-
-input StockMovementWhereUniqueInput {
-  id: String
-  AND: [StockMovementWhereInput!]
-  OR: [StockMovementWhereInput!]
-  NOT: [StockMovementWhereInput!]
-  storeId: StringFilter
-  direction: EnumMovementDirectionFilter
-  movementType: EnumMovementTypeFilter
-  referenceEntity: StringFilter
-  referenceId: StringFilter
-  createdAt: DateTimeFilter
-  store: StoreScalarRelationFilter
-  items: StockMovementItemListRelationFilter
-}
-
-input StockMovementItemCreateOrConnectWithoutProductVariantInput {
-  where: StockMovementItemWhereUniqueInput!
-  create: StockMovementItemCreateWithoutProductVariantInput!
-}
-
-input StockMovementItemWhereUniqueInput {
-  id: String
-  AND: [StockMovementItemWhereInput!]
-  OR: [StockMovementItemWhereInput!]
-  NOT: [StockMovementItemWhereInput!]
-  stockMovementId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  movement: StockMovementScalarRelationFilter
-  productVariant: ProductVariantScalarRelationFilter
-}
-
-input StockMovementItemCreateManyProductVariantInputEnvelope {
-  data: [StockMovementItemCreateManyProductVariantInput!]!
-  skipDuplicates: Boolean
-}
-
-input StockMovementItemCreateManyProductVariantInput {
-  id: String
-  stockMovementId: String!
-  quantity: Int!
-}
-
-input ProductVariantCreateOrConnectWithoutQuotationItemsInput {
-  where: ProductVariantWhereUniqueInput!
-  create: ProductVariantCreateWithoutQuotationItemsInput!
-}
-
-input QuotationItemCreateOrConnectWithoutQuotationInput {
-  where: QuotationItemWhereUniqueInput!
-  create: QuotationItemCreateWithoutQuotationInput!
-}
-
-input QuotationItemWhereUniqueInput {
-  id: String
-  AND: [QuotationItemWhereInput!]
-  OR: [QuotationItemWhereInput!]
-  NOT: [QuotationItemWhereInput!]
-  quotationId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  unitPrice: FloatFilter
-  quotation: QuotationScalarRelationFilter
-  productVariant: ProductVariantScalarRelationFilter
-}
-
-input QuotationItemCreateManyQuotationInputEnvelope {
-  data: [QuotationItemCreateManyQuotationInput!]!
-  skipDuplicates: Boolean
-}
-
-input QuotationItemCreateManyQuotationInput {
-  id: String
-  productVariantId: String!
-  quantity: Int!
-  unitPrice: Float!
-}
-
-input QuotationCreateOrConnectWithoutBillerInput {
-  where: QuotationWhereUniqueInput!
-  create: QuotationCreateWithoutBillerInput!
-}
-
-input QuotationCreateManyBillerInputEnvelope {
-  data: [QuotationCreateManyBillerInput!]!
-  skipDuplicates: Boolean
-}
-
-input QuotationCreateManyBillerInput {
-  id: String
-  type: SaleType!
-  channel: SaleChannel!
-  storeId: String!
-  consumerId: String
-  resellerId: String
-  status: QuotationStatus
-  totalAmount: Float!
-  saleOrderId: String
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input UserCreateOrConnectWithoutResellerTierHistoryInput {
-  where: UserWhereUniqueInput!
-  create: UserCreateWithoutResellerTierHistoryInput!
-}
-
-input ResellerTierHistoryCreateOrConnectWithoutAdminInput {
-  where: ResellerTierHistoryWhereUniqueInput!
-  create: ResellerTierHistoryCreateWithoutAdminInput!
-}
-
-input ResellerTierHistoryWhereUniqueInput {
-  id: String
-  AND: [ResellerTierHistoryWhereInput!]
-  OR: [ResellerTierHistoryWhereInput!]
-  NOT: [ResellerTierHistoryWhereInput!]
-  userId: StringFilter
-  fromTier: EnumUserTierFilter
-  toTier: EnumUserTierFilter
-  changedBy: StringFilter
-  changedAt: DateTimeFilter
-  user: UserScalarRelationFilter
-  admin: UserScalarRelationFilter
-}
-
-input ResellerTierHistoryCreateManyAdminInputEnvelope {
-  data: [ResellerTierHistoryCreateManyAdminInput!]!
-  skipDuplicates: Boolean
-}
-
-input ResellerTierHistoryCreateManyAdminInput {
-  id: String
-  userId: String!
-  fromTier: UserTier!
-  toTier: UserTier!
-  changedAt: DateTime
-}
-
-input UserCreateOrConnectWithoutResellerQuotationInput {
-  where: UserWhereUniqueInput!
-  create: UserCreateWithoutResellerQuotationInput!
-}
-
-input QuotationCreateOrConnectWithoutSaleOrderInput {
-  where: QuotationWhereUniqueInput!
-  create: QuotationCreateWithoutSaleOrderInput!
-}
-
-input SaleOrderCreateOrConnectWithoutFulfillmentInput {
-  where: SaleOrderWhereUniqueInput!
-  create: SaleOrderCreateWithoutFulfillmentInput!
-}
-
-input FulfillmentCreateOrConnectWithoutDeliveryPersonnelInput {
-  where: FulfillmentWhereUniqueInput!
-  create: FulfillmentCreateWithoutDeliveryPersonnelInput!
-}
-
-input FulfillmentCreateManyDeliveryPersonnelInputEnvelope {
-  data: [FulfillmentCreateManyDeliveryPersonnelInput!]!
-  skipDuplicates: Boolean
-}
-
-input FulfillmentCreateManyDeliveryPersonnelInput {
-  id: String
-  saleOrderId: String!
-  type: FulfillmentType!
-  deliveryAddress: String
-  status: FulfillmentStatus
-  cost: Float
-  confirmationPin: String
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input UserCreateOrConnectWithoutResellerTierHistoryChangedBysInput {
-  where: UserWhereUniqueInput!
-  create: UserCreateWithoutResellerTierHistoryChangedBysInput!
-}
-
-input ResellerTierHistoryCreateOrConnectWithoutUserInput {
-  where: ResellerTierHistoryWhereUniqueInput!
-  create: ResellerTierHistoryCreateWithoutUserInput!
-}
-
-input ResellerTierHistoryCreateManyUserInputEnvelope {
-  data: [ResellerTierHistoryCreateManyUserInput!]!
-  skipDuplicates: Boolean
-}
-
-input ResellerTierHistoryCreateManyUserInput {
-  id: String
-  fromTier: UserTier!
-  toTier: UserTier!
-  changedBy: String!
-  changedAt: DateTime
-}
-
-input UserCreateOrConnectWithoutPurchaseReturnApproversInput {
-  where: UserWhereUniqueInput!
-  create: UserCreateWithoutPurchaseReturnApproversInput!
-}
-
-input PurchaseReturnCreateOrConnectWithoutSupplierInput {
-  where: PurchaseReturnWhereUniqueInput!
-  create: PurchaseReturnCreateWithoutSupplierInput!
-}
-
-input PurchaseReturnWhereUniqueInput {
-  id: String
-  AND: [PurchaseReturnWhereInput!]
-  OR: [PurchaseReturnWhereInput!]
-  NOT: [PurchaseReturnWhereInput!]
-  supplierId: StringFilter
-  initiatedById: StringFilter
-  approvedById: StringFilter
-  status: EnumReturnStatusFilter
-  reason: StringNullableFilter
-  createdAt: DateTimeFilter
-  updatedAt: DateTimeFilter
-  supplier: SupplierScalarRelationFilter
-  initiatedBy: UserScalarRelationFilter
-  approvedBy: UserScalarRelationFilter
-  items: PurchaseReturnItemListRelationFilter
-}
-
-input PurchaseReturnCreateManySupplierInputEnvelope {
-  data: [PurchaseReturnCreateManySupplierInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseReturnCreateManySupplierInput {
-  id: String
-  initiatedById: String!
-  approvedById: String!
-  status: ReturnStatus!
-  reason: String
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input SupplierCreateOrConnectWithoutPurchaseOrdersInput {
-  where: SupplierWhereUniqueInput!
-  create: SupplierCreateWithoutPurchaseOrdersInput!
-}
-
-input SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput {
-  create: [SupplierPaymentCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput!]
-  createMany: SupplierPaymentCreateManyPurchaseOrderInputEnvelope
-  connect: [SupplierPaymentWhereUniqueInput!]
-}
-
-input SupplierPaymentCreateWithoutPurchaseOrderInput {
-  id: String
-  amount: Float!
-  paymentDate: DateTime!
-  method: String!
-  notes: String
-  supplier: SupplierCreateNestedOneWithoutPaymentsInput!
-}
-
-input SupplierCreateNestedOneWithoutPaymentsInput {
-  create: SupplierCreateWithoutPaymentsInput
-  connectOrCreate: SupplierCreateOrConnectWithoutPaymentsInput
-  connect: SupplierWhereUniqueInput
-}
-
-input SupplierCreateWithoutPaymentsInput {
-  id: String
-  name: String!
-  contactInfo: JSON
-  isFrequent: Boolean
-  creditLimit: Float!
-  currentBalance: Float
-  paymentTerms: String
-  notes: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  purchaseOrders: PurchaseOrderCreateNestedManyWithoutSupplierInput
-  returns: PurchaseReturnCreateNestedManyWithoutSupplierInput
-  catalogs: SupplierCatalogCreateNestedManyWithoutSupplierInput
-  quotes: SupplierQuoteCreateNestedManyWithoutSupplierInput
-  user: UserCreateNestedOneWithoutSupplierInput
-}
-
-input SupplierCreateOrConnectWithoutPaymentsInput {
-  where: SupplierWhereUniqueInput!
-  create: SupplierCreateWithoutPaymentsInput!
-}
-
-input SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput {
-  where: SupplierPaymentWhereUniqueInput!
-  create: SupplierPaymentCreateWithoutPurchaseOrderInput!
-}
-
-input SupplierPaymentCreateManyPurchaseOrderInputEnvelope {
-  data: [SupplierPaymentCreateManyPurchaseOrderInput!]!
-  skipDuplicates: Boolean
-}
-
-input SupplierPaymentCreateManyPurchaseOrderInput {
-  id: String
-  supplierId: String!
-  amount: Float!
-  paymentDate: DateTime!
-  method: String!
-  notes: String
-}
-
-input PurchaseOrderCreateOrConnectWithoutItemsInput {
-  where: PurchaseOrderWhereUniqueInput!
-  create: PurchaseOrderCreateWithoutItemsInput!
-}
-
-input PurchaseOrderItemCreateOrConnectWithoutProductVariantInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  create: PurchaseOrderItemCreateWithoutProductVariantInput!
-}
-
-input PurchaseOrderItemWhereUniqueInput {
-  id: String
-  AND: [PurchaseOrderItemWhereInput!]
-  OR: [PurchaseOrderItemWhereInput!]
-  NOT: [PurchaseOrderItemWhereInput!]
-  purchaseOrderId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  unitCost: FloatFilter
-  purchaseOrder: PurchaseOrderScalarRelationFilter
-  productVariant: ProductVariantScalarRelationFilter
-}
-
-input PurchaseOrderItemCreateManyProductVariantInputEnvelope {
-  data: [PurchaseOrderItemCreateManyProductVariantInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseOrderItemCreateManyProductVariantInput {
-  id: String
-  purchaseOrderId: String!
-  quantity: Int!
-  unitCost: Float!
-}
-
-input ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput {
-  where: ProductVariantWhereUniqueInput!
-  create: ProductVariantCreateWithoutPurchaseReturnItemsInput!
-}
-
-input StockReceiptBatchCreateNestedOneWithoutPurchaseReturnsInput {
-  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput
-  connectOrCreate: StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput
-  connect: StockReceiptBatchWhereUniqueInput
-}
-
-input StockReceiptBatchCreateWithoutPurchaseReturnsInput {
-  id: String
-  purchaseOrderId: String!
-  waybillUrl: String
-  receivedAt: DateTime
-  store: StoreCreateNestedOneWithoutReceiptsInput!
-  receivedBy: UserCreateNestedOneWithoutStockReceiptBatchReceivedBysInput!
-  confirmedBy: UserCreateNestedOneWithoutStockReceiptBatchConfirmedBysInput!
-  items: StockReceiptBatchItemCreateNestedManyWithoutBatchInput
-  PurchaseOrder: PurchaseOrderCreateNestedManyWithoutReceiptsInput
-}
-
-input PurchaseOrderCreateNestedManyWithoutReceiptsInput {
-  create: [PurchaseOrderCreateWithoutReceiptsInput!]
-  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutReceiptsInput!]
-  connect: [PurchaseOrderWhereUniqueInput!]
-}
-
-input PurchaseOrderCreateWithoutReceiptsInput {
-  id: String
-  invoiceNumber: String!
-  status: PurchaseOrderStatus!
-  phase: PurchasePhase
-  dueDate: DateTime!
-  totalAmount: Float!
-  createdAt: DateTime
-  updatedAt: DateTime
-  supplier: SupplierCreateNestedOneWithoutPurchaseOrdersInput!
-  items: PurchaseOrderItemCreateNestedManyWithoutPurchaseOrderInput
-  payments: SupplierPaymentCreateNestedManyWithoutPurchaseOrderInput
-}
-
-input PurchaseOrderCreateOrConnectWithoutReceiptsInput {
-  where: PurchaseOrderWhereUniqueInput!
-  create: PurchaseOrderCreateWithoutReceiptsInput!
-}
-
-input StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput {
-  where: StockReceiptBatchWhereUniqueInput!
-  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput!
-}
-
-input PurchaseReturnItemCreateOrConnectWithoutReturnInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  create: PurchaseReturnItemCreateWithoutReturnInput!
-}
-
-input PurchaseReturnItemCreateManyReturnInputEnvelope {
-  data: [PurchaseReturnItemCreateManyReturnInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseReturnItemCreateManyReturnInput {
-  id: String
-  productVariantId: String!
-  batchId: String!
-  quantity: Int!
-}
-
-input PurchaseReturnCreateOrConnectWithoutApprovedByInput {
-  where: PurchaseReturnWhereUniqueInput!
-  create: PurchaseReturnCreateWithoutApprovedByInput!
-}
-
-input PurchaseReturnCreateManyApprovedByInputEnvelope {
-  data: [PurchaseReturnCreateManyApprovedByInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseReturnCreateManyApprovedByInput {
-  id: String
-  supplierId: String!
-  initiatedById: String!
-  status: ReturnStatus!
-  reason: String
-  createdAt: DateTime
-  updatedAt: DateTime
-}
-
-input UserCreateOrConnectWithoutPurchaseReturnInitiatorsInput {
-  where: UserWhereUniqueInput!
-  create: UserCreateWithoutPurchaseReturnInitiatorsInput!
-}
-
-input PurchaseReturnCreateOrConnectWithoutItemsInput {
-  where: PurchaseReturnWhereUniqueInput!
-  create: PurchaseReturnCreateWithoutItemsInput!
-}
-
-input PurchaseReturnItemCreateOrConnectWithoutProductVariantInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  create: PurchaseReturnItemCreateWithoutProductVariantInput!
-}
-
-input PurchaseReturnItemCreateManyProductVariantInputEnvelope {
-  data: [PurchaseReturnItemCreateManyProductVariantInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseReturnItemCreateManyProductVariantInput {
-  id: String
-  purchaseReturnId: String!
-  batchId: String!
-  quantity: Int!
-}
-
-input ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput {
-  where: ProductVariantWhereUniqueInput!
-  create: ProductVariantCreateWithoutPurchaseOrderItemInput!
-}
-
-input PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  create: PurchaseOrderItemCreateWithoutPurchaseOrderInput!
-}
-
-input PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope {
-  data: [PurchaseOrderItemCreateManyPurchaseOrderInput!]!
-  skipDuplicates: Boolean
-}
-
-input PurchaseOrderItemCreateManyPurchaseOrderInput {
-  id: String
-  productVariantId: String!
-  quantity: Int!
-  unitCost: Float!
+  create: StoreCreateWithoutPurchaseOrdersInput!
 }
 
 input PurchaseOrderCreateOrConnectWithoutSupplierInput {
@@ -11816,6 +12035,7 @@ input PurchaseOrderCreateManySupplierInputEnvelope {
 
 input PurchaseOrderCreateManySupplierInput {
   id: String
+  storeId: String
   invoiceNumber: String!
   status: PurchaseOrderStatus!
   phase: PurchasePhase
@@ -12392,6 +12612,7 @@ input ProductVariantCreateWithoutTransferItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input ProductVariantCreateOrConnectWithoutTransferItemsInput {
@@ -13190,6 +13411,7 @@ input ProductVariantUpdateWithoutProductInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input FloatFieldUpdateOperationsInput {
@@ -13280,6 +13502,7 @@ input StoreUpdateWithoutStocksInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input BoolFieldUpdateOperationsInput {
@@ -13602,6 +13825,7 @@ input StoreUpdateWithoutCustomerProfileInput {
   Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input StockUpdateManyWithoutStoreNestedInput {
@@ -13673,6 +13897,7 @@ input ProductVariantUpdateWithoutStockItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input ProductUpdateOneRequiredWithoutVariantsNestedInput {
@@ -13789,6 +14014,7 @@ input StoreUpdateWithoutReceiptsInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input StockTransferUpdateManyWithoutFromStoreNestedInput {
@@ -13858,6 +14084,7 @@ input StoreUpdateWithoutTransfersInInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input StockReceiptBatchUpdateManyWithoutStoreNestedInput {
@@ -14141,6 +14368,7 @@ input StoreUpdateWithoutCustomerInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input StockTransferUpdateManyWithoutToStoreNestedInput {
@@ -14206,6 +14434,7 @@ input StoreUpdateWithoutTransfersOutInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input ConsumerSaleUpdateManyWithoutStoreNestedInput {
@@ -14592,6 +14821,7 @@ input StoreUpdateWithoutCustomerSalesInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input SalesReturnUpdateManyWithoutStoreNestedInput {
@@ -14938,6 +15168,7 @@ input StoreUpdateWithoutQuotationInput {
   Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input ResellerSaleUpdateManyWithoutStoreNestedInput {
@@ -15133,6 +15364,7 @@ input ProductVariantUpdateWithoutReceiptItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input QuotationItemUpdateManyWithoutProductVariantNestedInput {
@@ -15384,6 +15616,7 @@ input StoreUpdateWithoutManagerInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input StockMovementUpdateManyWithoutStoreNestedInput {
@@ -15488,6 +15721,7 @@ input ProductVariantUpdateWithoutStockMovementItemInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input ResellerSaleItemUpdateManyWithoutProductVariantNestedInput {
@@ -15824,6 +16058,7 @@ input ProductVariantUpdateWithoutConsumerItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input SalesReturnItemUpdateManyWithoutProductVariantNestedInput {
@@ -16242,6 +16477,7 @@ input StoreUpdateWithoutResellerSalesInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input CustomerUpdateManyWithoutPreferredStoreNestedInput {
@@ -16503,6 +16739,7 @@ input ProductVariantUpdateWithoutResellerItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput {
@@ -17160,6 +17397,7 @@ input PurchaseOrderUpdateWithoutSupplierInput {
   totalAmount: FloatFieldUpdateOperationsInput
   createdAt: DateTimeFieldUpdateOperationsInput
   updatedAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneWithoutPurchaseOrdersNestedInput
   items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
   receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
   payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
@@ -17173,115 +17411,349 @@ input EnumPurchasePhaseFieldUpdateOperationsInput {
   set: PurchasePhase
 }
 
-input PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput {
-  create: [PurchaseOrderItemCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput!]
-  upsert: [PurchaseOrderItemUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
-  createMany: PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope
-  set: [PurchaseOrderItemWhereUniqueInput!]
-  disconnect: [PurchaseOrderItemWhereUniqueInput!]
-  delete: [PurchaseOrderItemWhereUniqueInput!]
-  connect: [PurchaseOrderItemWhereUniqueInput!]
-  update: [PurchaseOrderItemUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
-  updateMany: [PurchaseOrderItemUpdateManyWithWhereWithoutPurchaseOrderInput!]
-  deleteMany: [PurchaseOrderItemScalarWhereInput!]
+input StoreUpdateOneWithoutPurchaseOrdersNestedInput {
+  create: StoreCreateWithoutPurchaseOrdersInput
+  connectOrCreate: StoreCreateOrConnectWithoutPurchaseOrdersInput
+  upsert: StoreUpsertWithoutPurchaseOrdersInput
+  disconnect: StoreWhereInput
+  delete: StoreWhereInput
+  connect: StoreWhereUniqueInput
+  update: StoreUpdateToOneWithWhereWithoutPurchaseOrdersInput
 }
 
-input PurchaseOrderItemUpsertWithWhereUniqueWithoutPurchaseOrderInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  update: PurchaseOrderItemUpdateWithoutPurchaseOrderInput!
-  create: PurchaseOrderItemCreateWithoutPurchaseOrderInput!
+input StoreUpsertWithoutPurchaseOrdersInput {
+  update: StoreUpdateWithoutPurchaseOrdersInput!
+  create: StoreCreateWithoutPurchaseOrdersInput!
+  where: StoreWhereInput
 }
 
-input PurchaseOrderItemUpdateWithoutPurchaseOrderInput {
+input StoreUpdateWithoutPurchaseOrdersInput {
   id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  unitCost: FloatFieldUpdateOperationsInput
-  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseOrderItemNestedInput
-}
-
-input ProductVariantUpdateOneRequiredWithoutPurchaseOrderItemNestedInput {
-  create: ProductVariantCreateWithoutPurchaseOrderItemInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput
-  upsert: ProductVariantUpsertWithoutPurchaseOrderItemInput
-  connect: ProductVariantWhereUniqueInput
-  update: ProductVariantUpdateToOneWithWhereWithoutPurchaseOrderItemInput
-}
-
-input ProductVariantUpsertWithoutPurchaseOrderItemInput {
-  update: ProductVariantUpdateWithoutPurchaseOrderItemInput!
-  create: ProductVariantCreateWithoutPurchaseOrderItemInput!
-  where: ProductVariantWhereInput
-}
-
-input ProductVariantUpdateWithoutPurchaseOrderItemInput {
-  id: StringFieldUpdateOperationsInput
-  size: StringFieldUpdateOperationsInput
-  concentration: StringFieldUpdateOperationsInput
-  packaging: StringFieldUpdateOperationsInput
-  barcode: NullableStringFieldUpdateOperationsInput
-  price: FloatFieldUpdateOperationsInput
-  resellerPrice: FloatFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  location: NullableStringFieldUpdateOperationsInput
+  isMain: BoolFieldUpdateOperationsInput
   createdAt: DateTimeFieldUpdateOperationsInput
   updatedAt: DateTimeFieldUpdateOperationsInput
-  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
-  stockItems: StockUpdateManyWithoutProductVariantNestedInput
-  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
-  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
-  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
-  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
-  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
-  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
-  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
-  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
-  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
-  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
-  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  manager: UserUpdateOneRequiredWithoutStoreNestedInput
+  stocks: StockUpdateManyWithoutStoreNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutStoreNestedInput
+  transfersOut: StockTransferUpdateManyWithoutFromStoreNestedInput
+  transfersIn: StockTransferUpdateManyWithoutToStoreNestedInput
+  customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
+  salesReturns: SalesReturnUpdateManyWithoutStoreNestedInput
+  resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
+  movements: StockMovementUpdateManyWithoutStoreNestedInput
+  Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
+  CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
+  Quotation: QuotationUpdateManyWithoutStoreNestedInput
+  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
 }
 
-input PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput {
-  create: [PurchaseReturnItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: PurchaseReturnItemCreateManyProductVariantInputEnvelope
-  set: [PurchaseReturnItemWhereUniqueInput!]
-  disconnect: [PurchaseReturnItemWhereUniqueInput!]
-  delete: [PurchaseReturnItemWhereUniqueInput!]
-  connect: [PurchaseReturnItemWhereUniqueInput!]
-  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [PurchaseReturnItemScalarWhereInput!]
+input CustomerProfileUpdateManyWithoutPreferredStoreNestedInput {
+  create: [CustomerProfileCreateWithoutPreferredStoreInput!]
+  connectOrCreate: [CustomerProfileCreateOrConnectWithoutPreferredStoreInput!]
+  upsert: [CustomerProfileUpsertWithWhereUniqueWithoutPreferredStoreInput!]
+  createMany: CustomerProfileCreateManyPreferredStoreInputEnvelope
+  set: [CustomerProfileWhereUniqueInput!]
+  disconnect: [CustomerProfileWhereUniqueInput!]
+  delete: [CustomerProfileWhereUniqueInput!]
+  connect: [CustomerProfileWhereUniqueInput!]
+  update: [CustomerProfileUpdateWithWhereUniqueWithoutPreferredStoreInput!]
+  updateMany: [CustomerProfileUpdateManyWithWhereWithoutPreferredStoreInput!]
+  deleteMany: [CustomerProfileScalarWhereInput!]
 }
 
-input PurchaseReturnItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  update: PurchaseReturnItemUpdateWithoutProductVariantInput!
-  create: PurchaseReturnItemCreateWithoutProductVariantInput!
+input CustomerProfileUpsertWithWhereUniqueWithoutPreferredStoreInput {
+  where: CustomerProfileWhereUniqueInput!
+  update: CustomerProfileUpdateWithoutPreferredStoreInput!
+  create: CustomerProfileCreateWithoutPreferredStoreInput!
 }
 
-input PurchaseReturnItemUpdateWithoutProductVariantInput {
+input CustomerProfileUpdateWithoutPreferredStoreInput {
+  fullName: StringFieldUpdateOperationsInput
+  phone: NullableStringFieldUpdateOperationsInput
+  email: NullableStringFieldUpdateOperationsInput
+  gender: NullableStringFieldUpdateOperationsInput
+  birthday: NullableDateTimeFieldUpdateOperationsInput
+  profileStatus: EnumProfileStatusFieldUpdateOperationsInput
+  requestedAt: DateTimeFieldUpdateOperationsInput
+  activatedAt: NullableDateTimeFieldUpdateOperationsInput
+  isPhoneVerified: BoolFieldUpdateOperationsInput
+  phoneVerificationCode: NullableStringFieldUpdateOperationsInput
+  phoneVerificationCodeExpiry: NullableDateTimeFieldUpdateOperationsInput
+  user: UserUpdateOneRequiredWithoutCustomerProfileNestedInput
+  referredBy: CustomerProfileUpdateOneWithoutReferralsNestedInput
+  referrals: CustomerProfileUpdateManyWithoutReferredByNestedInput
+  sales: ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput
+  preferences: CustomerPreferenceProfileUpdateOneWithoutCustomerProfileNestedInput
+}
+
+input CustomerProfileUpdateOneWithoutReferralsNestedInput {
+  create: CustomerProfileCreateWithoutReferralsInput
+  connectOrCreate: CustomerProfileCreateOrConnectWithoutReferralsInput
+  upsert: CustomerProfileUpsertWithoutReferralsInput
+  disconnect: CustomerProfileWhereInput
+  delete: CustomerProfileWhereInput
+  connect: CustomerProfileWhereUniqueInput
+  update: CustomerProfileUpdateToOneWithWhereWithoutReferralsInput
+}
+
+input CustomerProfileUpsertWithoutReferralsInput {
+  update: CustomerProfileUpdateWithoutReferralsInput!
+  create: CustomerProfileCreateWithoutReferralsInput!
+  where: CustomerProfileWhereInput
+}
+
+input CustomerProfileUpdateWithoutReferralsInput {
+  fullName: StringFieldUpdateOperationsInput
+  phone: NullableStringFieldUpdateOperationsInput
+  email: NullableStringFieldUpdateOperationsInput
+  gender: NullableStringFieldUpdateOperationsInput
+  birthday: NullableDateTimeFieldUpdateOperationsInput
+  profileStatus: EnumProfileStatusFieldUpdateOperationsInput
+  requestedAt: DateTimeFieldUpdateOperationsInput
+  activatedAt: NullableDateTimeFieldUpdateOperationsInput
+  isPhoneVerified: BoolFieldUpdateOperationsInput
+  phoneVerificationCode: NullableStringFieldUpdateOperationsInput
+  phoneVerificationCodeExpiry: NullableDateTimeFieldUpdateOperationsInput
+  user: UserUpdateOneRequiredWithoutCustomerProfileNestedInput
+  preferredStore: StoreUpdateOneWithoutCustomerProfileNestedInput
+  referredBy: CustomerProfileUpdateOneWithoutReferralsNestedInput
+  sales: ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput
+  preferences: CustomerPreferenceProfileUpdateOneWithoutCustomerProfileNestedInput
+}
+
+input ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput {
+  create: [ConsumerSaleCreateWithoutCustomerProfileInput!]
+  connectOrCreate: [ConsumerSaleCreateOrConnectWithoutCustomerProfileInput!]
+  upsert: [ConsumerSaleUpsertWithWhereUniqueWithoutCustomerProfileInput!]
+  set: [ConsumerSaleWhereUniqueInput!]
+  disconnect: [ConsumerSaleWhereUniqueInput!]
+  delete: [ConsumerSaleWhereUniqueInput!]
+  connect: [ConsumerSaleWhereUniqueInput!]
+  update: [ConsumerSaleUpdateWithWhereUniqueWithoutCustomerProfileInput!]
+  updateMany: [ConsumerSaleUpdateManyWithWhereWithoutCustomerProfileInput!]
+  deleteMany: [ConsumerSaleScalarWhereInput!]
+}
+
+input ConsumerSaleUpsertWithWhereUniqueWithoutCustomerProfileInput {
+  where: ConsumerSaleWhereUniqueInput!
+  update: ConsumerSaleUpdateWithoutCustomerProfileInput!
+  create: ConsumerSaleCreateWithoutCustomerProfileInput!
+}
+
+input ConsumerSaleUpdateWithoutCustomerProfileInput {
   id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  return: PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput
-  batch: StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput
+  channel: EnumSaleChannelFieldUpdateOperationsInput
+  status: EnumSaleStatusFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
+  adjustmentType: NullableEnumAdjustmentTypeFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  customer: CustomerUpdateOneWithoutSalesNestedInput
+  store: StoreUpdateOneRequiredWithoutCustomerSalesNestedInput
+  biller: UserUpdateOneRequiredWithoutConsumerSaleNestedInput
+  adjustedBy: UserUpdateOneWithoutConsumerSaleAdjustedBysNestedInput
+  quotation: QuotationUpdateOneWithoutConsumerSaleNestedInput
+  items: ConsumerSaleItemUpdateManyWithoutSaleNestedInput
+  payments: ConsumerPaymentUpdateManyWithoutSaleNestedInput
+  receipt: ConsumerReceiptUpdateOneWithoutSaleNestedInput
+  SalesReturn: SalesReturnUpdateManyWithoutConsumerSaleNestedInput
+  SaleOrder: SaleOrderUpdateOneRequiredWithoutConsumerSaleNestedInput
 }
 
-input PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput {
-  create: PurchaseReturnCreateWithoutItemsInput
-  connectOrCreate: PurchaseReturnCreateOrConnectWithoutItemsInput
-  upsert: PurchaseReturnUpsertWithoutItemsInput
-  connect: PurchaseReturnWhereUniqueInput
-  update: PurchaseReturnUpdateToOneWithWhereWithoutItemsInput
+input SalesReturnUpdateManyWithoutConsumerSaleNestedInput {
+  create: [SalesReturnCreateWithoutConsumerSaleInput!]
+  connectOrCreate: [SalesReturnCreateOrConnectWithoutConsumerSaleInput!]
+  upsert: [SalesReturnUpsertWithWhereUniqueWithoutConsumerSaleInput!]
+  createMany: SalesReturnCreateManyConsumerSaleInputEnvelope
+  set: [SalesReturnWhereUniqueInput!]
+  disconnect: [SalesReturnWhereUniqueInput!]
+  delete: [SalesReturnWhereUniqueInput!]
+  connect: [SalesReturnWhereUniqueInput!]
+  update: [SalesReturnUpdateWithWhereUniqueWithoutConsumerSaleInput!]
+  updateMany: [SalesReturnUpdateManyWithWhereWithoutConsumerSaleInput!]
+  deleteMany: [SalesReturnScalarWhereInput!]
 }
 
-input PurchaseReturnUpsertWithoutItemsInput {
-  update: PurchaseReturnUpdateWithoutItemsInput!
-  create: PurchaseReturnCreateWithoutItemsInput!
-  where: PurchaseReturnWhereInput
+input SalesReturnUpsertWithWhereUniqueWithoutConsumerSaleInput {
+  where: SalesReturnWhereUniqueInput!
+  update: SalesReturnUpdateWithoutConsumerSaleInput!
+  create: SalesReturnCreateWithoutConsumerSaleInput!
 }
 
-input PurchaseReturnUpdateWithoutItemsInput {
+input SalesReturnUpdateWithoutConsumerSaleInput {
+  id: StringFieldUpdateOperationsInput
+  type: EnumSaleTypeFieldUpdateOperationsInput
+  status: EnumReturnStatusFieldUpdateOperationsInput
+  returnLocation: EnumReturnLocationFieldUpdateOperationsInput
+  isApprovedLate: BoolFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  resellerSale: ResellerSaleUpdateOneWithoutSalesReturnNestedInput
+  returnedBy: UserUpdateOneRequiredWithoutSalesReturnRequestersNestedInput
+  receivedBy: UserUpdateOneRequiredWithoutSalesReturnReceiversNestedInput
+  approvedBy: UserUpdateOneWithoutSalesReturnNestedInput
+  store: StoreUpdateOneRequiredWithoutSalesReturnsNestedInput
+  items: SalesReturnItemUpdateManyWithoutReturnNestedInput
+}
+
+input StoreUpdateOneRequiredWithoutSalesReturnsNestedInput {
+  create: StoreCreateWithoutSalesReturnsInput
+  connectOrCreate: StoreCreateOrConnectWithoutSalesReturnsInput
+  upsert: StoreUpsertWithoutSalesReturnsInput
+  connect: StoreWhereUniqueInput
+  update: StoreUpdateToOneWithWhereWithoutSalesReturnsInput
+}
+
+input StoreUpsertWithoutSalesReturnsInput {
+  update: StoreUpdateWithoutSalesReturnsInput!
+  create: StoreCreateWithoutSalesReturnsInput!
+  where: StoreWhereInput
+}
+
+input StoreUpdateWithoutSalesReturnsInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  location: NullableStringFieldUpdateOperationsInput
+  isMain: BoolFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  manager: UserUpdateOneRequiredWithoutStoreNestedInput
+  stocks: StockUpdateManyWithoutStoreNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutStoreNestedInput
+  transfersOut: StockTransferUpdateManyWithoutFromStoreNestedInput
+  transfersIn: StockTransferUpdateManyWithoutToStoreNestedInput
+  customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
+  resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
+  movements: StockMovementUpdateManyWithoutStoreNestedInput
+  Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
+  CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
+  Quotation: QuotationUpdateManyWithoutStoreNestedInput
+  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
+}
+
+input QuotationUpdateManyWithoutStoreNestedInput {
+  create: [QuotationCreateWithoutStoreInput!]
+  connectOrCreate: [QuotationCreateOrConnectWithoutStoreInput!]
+  upsert: [QuotationUpsertWithWhereUniqueWithoutStoreInput!]
+  createMany: QuotationCreateManyStoreInputEnvelope
+  set: [QuotationWhereUniqueInput!]
+  disconnect: [QuotationWhereUniqueInput!]
+  delete: [QuotationWhereUniqueInput!]
+  connect: [QuotationWhereUniqueInput!]
+  update: [QuotationUpdateWithWhereUniqueWithoutStoreInput!]
+  updateMany: [QuotationUpdateManyWithWhereWithoutStoreInput!]
+  deleteMany: [QuotationScalarWhereInput!]
+}
+
+input QuotationUpsertWithWhereUniqueWithoutStoreInput {
+  where: QuotationWhereUniqueInput!
+  update: QuotationUpdateWithoutStoreInput!
+  create: QuotationCreateWithoutStoreInput!
+}
+
+input QuotationUpdateWithoutStoreInput {
+  id: StringFieldUpdateOperationsInput
+  type: EnumSaleTypeFieldUpdateOperationsInput
+  channel: EnumSaleChannelFieldUpdateOperationsInput
+  status: EnumQuotationStatusFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  biller: UserUpdateOneWithoutBillerQuotationNestedInput
+  consumer: CustomerUpdateOneWithoutQuotationNestedInput
+  reseller: UserUpdateOneWithoutResellerQuotationNestedInput
+  items: QuotationItemUpdateManyWithoutQuotationNestedInput
+  sale: ResellerSaleUpdateOneWithoutQuotationNestedInput
+  SaleOrder: SaleOrderUpdateOneWithoutQuotationNestedInput
+  ConsumerSale: ConsumerSaleUpdateManyWithoutQuotationNestedInput
+}
+
+input UserUpdateOneWithoutResellerQuotationNestedInput {
+  create: UserCreateWithoutResellerQuotationInput
+  connectOrCreate: UserCreateOrConnectWithoutResellerQuotationInput
+  upsert: UserUpsertWithoutResellerQuotationInput
+  disconnect: UserWhereInput
+  delete: UserWhereInput
+  connect: UserWhereUniqueInput
+  update: UserUpdateToOneWithWhereWithoutResellerQuotationInput
+}
+
+input UserUpsertWithoutResellerQuotationInput {
+  update: UserUpdateWithoutResellerQuotationInput!
+  create: UserCreateWithoutResellerQuotationInput!
+  where: UserWhereInput
+}
+
+input UserUpdateWithoutResellerQuotationInput {
+  id: StringFieldUpdateOperationsInput
+  email: StringFieldUpdateOperationsInput
+  passwordHash: StringFieldUpdateOperationsInput
+  tier: NullableEnumUserTierFieldUpdateOperationsInput
+  referralCode: NullableStringFieldUpdateOperationsInput
+  referredBy: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  isEmailVerified: BoolFieldUpdateOperationsInput
+  emailVerificationToken: NullableStringFieldUpdateOperationsInput
+  emailVerificationTokenExpiry: NullableDateTimeFieldUpdateOperationsInput
+  role: RoleUpdateOneRequiredWithoutUsersNestedInput
+  resellerProfile: ResellerProfileUpdateOneWithoutUserNestedInput
+  customerProfile: CustomerProfileUpdateOneWithoutUserNestedInput
+  resellerPaymentsMade: ResellerPaymentUpdateManyWithoutResellerNestedInput
+  resellerPaymentsReceived: ResellerPaymentUpdateManyWithoutReceivedByNestedInput
+  adminLogs: AdminActionLogUpdateManyWithoutAdminNestedInput
+  supportMessages: SupportMessageUpdateManyWithoutUserNestedInput
+  ConsumerSale: ConsumerSaleUpdateManyWithoutBillerNestedInput
+  ConsumerSaleAdjustedBys: ConsumerSaleUpdateManyWithoutAdjustedByNestedInput
+  StockReceiptBatchReceivedBys: StockReceiptBatchUpdateManyWithoutReceivedByNestedInput
+  StockReceiptBatchConfirmedBys: StockReceiptBatchUpdateManyWithoutConfirmedByNestedInput
+  StockTransferRequests: StockTransferUpdateManyWithoutRequestedByNestedInput
+  StockTransferApprovals: StockTransferUpdateManyWithoutApprovedByNestedInput
+  Store: StoreUpdateManyWithoutManagerNestedInput
+  ConsumerReceipt: ConsumerReceiptUpdateManyWithoutIssuedByNestedInput
+  ResellerSales: ResellerSaleUpdateManyWithoutResellerNestedInput
+  BillerResellerSale: ResellerSaleUpdateManyWithoutBillerNestedInput
+  ResellerSale: ResellerSaleUpdateManyWithoutApprovedByNestedInput
+  SalesReturnReceivers: SalesReturnUpdateManyWithoutReceivedByNestedInput
+  SalesReturnRequesters: SalesReturnUpdateManyWithoutReturnedByNestedInput
+  SalesReturn: SalesReturnUpdateManyWithoutApprovedByNestedInput
+  PurchaseReturnInitiators: PurchaseReturnUpdateManyWithoutInitiatedByNestedInput
+  PurchaseReturnApprovers: PurchaseReturnUpdateManyWithoutApprovedByNestedInput
+  Payment: PaymentUpdateManyWithoutReceivedByNestedInput
+  ResellerTierHistory: ResellerTierHistoryUpdateManyWithoutUserNestedInput
+  ResellerTierHistoryChangedBys: ResellerTierHistoryUpdateManyWithoutAdminNestedInput
+  ResellerProfile: ResellerProfileUpdateManyWithoutBillerNestedInput
+  Notification: NotificationUpdateManyWithoutUserNestedInput
+  Fulfillment: FulfillmentUpdateManyWithoutDeliveryPersonnelNestedInput
+  BillerQuotation: QuotationUpdateManyWithoutBillerNestedInput
+  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutRequestedByNestedInput
+  Supplier: SupplierUpdateManyWithoutUserNestedInput
+}
+
+input PurchaseReturnUpdateManyWithoutApprovedByNestedInput {
+  create: [PurchaseReturnCreateWithoutApprovedByInput!]
+  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutApprovedByInput!]
+  upsert: [PurchaseReturnUpsertWithWhereUniqueWithoutApprovedByInput!]
+  createMany: PurchaseReturnCreateManyApprovedByInputEnvelope
+  set: [PurchaseReturnWhereUniqueInput!]
+  disconnect: [PurchaseReturnWhereUniqueInput!]
+  delete: [PurchaseReturnWhereUniqueInput!]
+  connect: [PurchaseReturnWhereUniqueInput!]
+  update: [PurchaseReturnUpdateWithWhereUniqueWithoutApprovedByInput!]
+  updateMany: [PurchaseReturnUpdateManyWithWhereWithoutApprovedByInput!]
+  deleteMany: [PurchaseReturnScalarWhereInput!]
+}
+
+input PurchaseReturnUpsertWithWhereUniqueWithoutApprovedByInput {
+  where: PurchaseReturnWhereUniqueInput!
+  update: PurchaseReturnUpdateWithoutApprovedByInput!
+  create: PurchaseReturnCreateWithoutApprovedByInput!
+}
+
+input PurchaseReturnUpdateWithoutApprovedByInput {
   id: StringFieldUpdateOperationsInput
   status: EnumReturnStatusFieldUpdateOperationsInput
   reason: NullableStringFieldUpdateOperationsInput
@@ -17289,7 +17761,7 @@ input PurchaseReturnUpdateWithoutItemsInput {
   updatedAt: DateTimeFieldUpdateOperationsInput
   supplier: SupplierUpdateOneRequiredWithoutReturnsNestedInput
   initiatedBy: UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput
-  approvedBy: UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput
+  items: PurchaseReturnItemUpdateManyWithoutReturnNestedInput
 }
 
 input UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput {
@@ -17340,600 +17812,6 @@ input UserUpdateWithoutPurchaseReturnInitiatorsInput {
   SalesReturnRequesters: SalesReturnUpdateManyWithoutReturnedByNestedInput
   SalesReturn: SalesReturnUpdateManyWithoutApprovedByNestedInput
   PurchaseReturnApprovers: PurchaseReturnUpdateManyWithoutApprovedByNestedInput
-  Payment: PaymentUpdateManyWithoutReceivedByNestedInput
-  ResellerTierHistory: ResellerTierHistoryUpdateManyWithoutUserNestedInput
-  ResellerTierHistoryChangedBys: ResellerTierHistoryUpdateManyWithoutAdminNestedInput
-  ResellerProfile: ResellerProfileUpdateManyWithoutBillerNestedInput
-  Notification: NotificationUpdateManyWithoutUserNestedInput
-  Fulfillment: FulfillmentUpdateManyWithoutDeliveryPersonnelNestedInput
-  BillerQuotation: QuotationUpdateManyWithoutBillerNestedInput
-  ResellerQuotation: QuotationUpdateManyWithoutResellerNestedInput
-  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutRequestedByNestedInput
-  Supplier: SupplierUpdateManyWithoutUserNestedInput
-}
-
-input PurchaseReturnUpdateManyWithoutApprovedByNestedInput {
-  create: [PurchaseReturnCreateWithoutApprovedByInput!]
-  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutApprovedByInput!]
-  upsert: [PurchaseReturnUpsertWithWhereUniqueWithoutApprovedByInput!]
-  createMany: PurchaseReturnCreateManyApprovedByInputEnvelope
-  set: [PurchaseReturnWhereUniqueInput!]
-  disconnect: [PurchaseReturnWhereUniqueInput!]
-  delete: [PurchaseReturnWhereUniqueInput!]
-  connect: [PurchaseReturnWhereUniqueInput!]
-  update: [PurchaseReturnUpdateWithWhereUniqueWithoutApprovedByInput!]
-  updateMany: [PurchaseReturnUpdateManyWithWhereWithoutApprovedByInput!]
-  deleteMany: [PurchaseReturnScalarWhereInput!]
-}
-
-input PurchaseReturnUpsertWithWhereUniqueWithoutApprovedByInput {
-  where: PurchaseReturnWhereUniqueInput!
-  update: PurchaseReturnUpdateWithoutApprovedByInput!
-  create: PurchaseReturnCreateWithoutApprovedByInput!
-}
-
-input PurchaseReturnUpdateWithoutApprovedByInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumReturnStatusFieldUpdateOperationsInput
-  reason: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutReturnsNestedInput
-  initiatedBy: UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput
-  items: PurchaseReturnItemUpdateManyWithoutReturnNestedInput
-}
-
-input PurchaseReturnItemUpdateManyWithoutReturnNestedInput {
-  create: [PurchaseReturnItemCreateWithoutReturnInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutReturnInput!]
-  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutReturnInput!]
-  createMany: PurchaseReturnItemCreateManyReturnInputEnvelope
-  set: [PurchaseReturnItemWhereUniqueInput!]
-  disconnect: [PurchaseReturnItemWhereUniqueInput!]
-  delete: [PurchaseReturnItemWhereUniqueInput!]
-  connect: [PurchaseReturnItemWhereUniqueInput!]
-  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutReturnInput!]
-  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutReturnInput!]
-  deleteMany: [PurchaseReturnItemScalarWhereInput!]
-}
-
-input PurchaseReturnItemUpsertWithWhereUniqueWithoutReturnInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  update: PurchaseReturnItemUpdateWithoutReturnInput!
-  create: PurchaseReturnItemCreateWithoutReturnInput!
-}
-
-input PurchaseReturnItemUpdateWithoutReturnInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput
-  batch: StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput
-}
-
-input ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput {
-  create: ProductVariantCreateWithoutPurchaseReturnItemsInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput
-  upsert: ProductVariantUpsertWithoutPurchaseReturnItemsInput
-  connect: ProductVariantWhereUniqueInput
-  update: ProductVariantUpdateToOneWithWhereWithoutPurchaseReturnItemsInput
-}
-
-input ProductVariantUpsertWithoutPurchaseReturnItemsInput {
-  update: ProductVariantUpdateWithoutPurchaseReturnItemsInput!
-  create: ProductVariantCreateWithoutPurchaseReturnItemsInput!
-  where: ProductVariantWhereInput
-}
-
-input ProductVariantUpdateWithoutPurchaseReturnItemsInput {
-  id: StringFieldUpdateOperationsInput
-  size: StringFieldUpdateOperationsInput
-  concentration: StringFieldUpdateOperationsInput
-  packaging: StringFieldUpdateOperationsInput
-  barcode: NullableStringFieldUpdateOperationsInput
-  price: FloatFieldUpdateOperationsInput
-  resellerPrice: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
-  stockItems: StockUpdateManyWithoutProductVariantNestedInput
-  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
-  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
-  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
-  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
-  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
-  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
-  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
-  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
-  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
-  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
-  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
-}
-
-input StockTransferItemUpdateManyWithoutProductVariantNestedInput {
-  create: [StockTransferItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [StockTransferItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [StockTransferItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: StockTransferItemCreateManyProductVariantInputEnvelope
-  set: [StockTransferItemWhereUniqueInput!]
-  disconnect: [StockTransferItemWhereUniqueInput!]
-  delete: [StockTransferItemWhereUniqueInput!]
-  connect: [StockTransferItemWhereUniqueInput!]
-  update: [StockTransferItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [StockTransferItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [StockTransferItemScalarWhereInput!]
-}
-
-input StockTransferItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: StockTransferItemWhereUniqueInput!
-  update: StockTransferItemUpdateWithoutProductVariantInput!
-  create: StockTransferItemCreateWithoutProductVariantInput!
-}
-
-input StockTransferItemUpdateWithoutProductVariantInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  transfer: StockTransferUpdateOneRequiredWithoutItemsNestedInput
-}
-
-input StockTransferUpdateOneRequiredWithoutItemsNestedInput {
-  create: StockTransferCreateWithoutItemsInput
-  connectOrCreate: StockTransferCreateOrConnectWithoutItemsInput
-  upsert: StockTransferUpsertWithoutItemsInput
-  connect: StockTransferWhereUniqueInput
-  update: StockTransferUpdateToOneWithWhereWithoutItemsInput
-}
-
-input StockTransferUpsertWithoutItemsInput {
-  update: StockTransferUpdateWithoutItemsInput!
-  create: StockTransferCreateWithoutItemsInput!
-  where: StockTransferWhereInput
-}
-
-input StockTransferUpdateWithoutItemsInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumTransferStatusFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  fromStore: StoreUpdateOneRequiredWithoutTransfersOutNestedInput
-  toStore: StoreUpdateOneRequiredWithoutTransfersInNestedInput
-  requestedBy: UserUpdateOneRequiredWithoutStockTransferRequestsNestedInput
-  approvedBy: UserUpdateOneRequiredWithoutStockTransferApprovalsNestedInput
-}
-
-input StockTransferUpdateToOneWithWhereWithoutItemsInput {
-  where: StockTransferWhereInput
-  data: StockTransferUpdateWithoutItemsInput!
-}
-
-input StockTransferItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: StockTransferItemWhereUniqueInput!
-  data: StockTransferItemUpdateWithoutProductVariantInput!
-}
-
-input StockTransferItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: StockTransferItemScalarWhereInput!
-  data: StockTransferItemUpdateManyMutationInput!
-}
-
-input StockTransferItemScalarWhereInput {
-  AND: [StockTransferItemScalarWhereInput!]
-  OR: [StockTransferItemScalarWhereInput!]
-  NOT: [StockTransferItemScalarWhereInput!]
-  id: StringFilter
-  stockTransferId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-}
-
-input StockTransferItemUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-}
-
-input ProductSalesStatsUpdateOneWithoutProductVariantNestedInput {
-  create: ProductSalesStatsCreateWithoutProductVariantInput
-  connectOrCreate: ProductSalesStatsCreateOrConnectWithoutProductVariantInput
-  upsert: ProductSalesStatsUpsertWithoutProductVariantInput
-  disconnect: ProductSalesStatsWhereInput
-  delete: ProductSalesStatsWhereInput
-  connect: ProductSalesStatsWhereUniqueInput
-  update: ProductSalesStatsUpdateToOneWithWhereWithoutProductVariantInput
-}
-
-input ProductSalesStatsUpsertWithoutProductVariantInput {
-  update: ProductSalesStatsUpdateWithoutProductVariantInput!
-  create: ProductSalesStatsCreateWithoutProductVariantInput!
-  where: ProductSalesStatsWhereInput
-}
-
-input ProductSalesStatsUpdateWithoutProductVariantInput {
-  id: StringFieldUpdateOperationsInput
-  totalSold: IntFieldUpdateOperationsInput
-  totalReturned: IntFieldUpdateOperationsInput
-  lastSoldAt: NullableDateTimeFieldUpdateOperationsInput
-  monthlySales: JSON
-}
-
-input ProductSalesStatsUpdateToOneWithWhereWithoutProductVariantInput {
-  where: ProductSalesStatsWhereInput
-  data: ProductSalesStatsUpdateWithoutProductVariantInput!
-}
-
-input PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput {
-  create: [PurchaseOrderItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [PurchaseOrderItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: PurchaseOrderItemCreateManyProductVariantInputEnvelope
-  set: [PurchaseOrderItemWhereUniqueInput!]
-  disconnect: [PurchaseOrderItemWhereUniqueInput!]
-  delete: [PurchaseOrderItemWhereUniqueInput!]
-  connect: [PurchaseOrderItemWhereUniqueInput!]
-  update: [PurchaseOrderItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [PurchaseOrderItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [PurchaseOrderItemScalarWhereInput!]
-}
-
-input PurchaseOrderItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  update: PurchaseOrderItemUpdateWithoutProductVariantInput!
-  create: PurchaseOrderItemCreateWithoutProductVariantInput!
-}
-
-input PurchaseOrderItemUpdateWithoutProductVariantInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  unitCost: FloatFieldUpdateOperationsInput
-  purchaseOrder: PurchaseOrderUpdateOneRequiredWithoutItemsNestedInput
-}
-
-input PurchaseOrderUpdateOneRequiredWithoutItemsNestedInput {
-  create: PurchaseOrderCreateWithoutItemsInput
-  connectOrCreate: PurchaseOrderCreateOrConnectWithoutItemsInput
-  upsert: PurchaseOrderUpsertWithoutItemsInput
-  connect: PurchaseOrderWhereUniqueInput
-  update: PurchaseOrderUpdateToOneWithWhereWithoutItemsInput
-}
-
-input PurchaseOrderUpsertWithoutItemsInput {
-  update: PurchaseOrderUpdateWithoutItemsInput!
-  create: PurchaseOrderCreateWithoutItemsInput!
-  where: PurchaseOrderWhereInput
-}
-
-input PurchaseOrderUpdateWithoutItemsInput {
-  id: StringFieldUpdateOperationsInput
-  invoiceNumber: StringFieldUpdateOperationsInput
-  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
-  phase: EnumPurchasePhaseFieldUpdateOperationsInput
-  dueDate: DateTimeFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
-  receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
-  payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
-}
-
-input SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput {
-  create: SupplierCreateWithoutPurchaseOrdersInput
-  connectOrCreate: SupplierCreateOrConnectWithoutPurchaseOrdersInput
-  upsert: SupplierUpsertWithoutPurchaseOrdersInput
-  connect: SupplierWhereUniqueInput
-  update: SupplierUpdateToOneWithWhereWithoutPurchaseOrdersInput
-}
-
-input SupplierUpsertWithoutPurchaseOrdersInput {
-  update: SupplierUpdateWithoutPurchaseOrdersInput!
-  create: SupplierCreateWithoutPurchaseOrdersInput!
-  where: SupplierWhereInput
-}
-
-input SupplierUpdateWithoutPurchaseOrdersInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-  contactInfo: JSON
-  isFrequent: BoolFieldUpdateOperationsInput
-  creditLimit: FloatFieldUpdateOperationsInput
-  currentBalance: FloatFieldUpdateOperationsInput
-  paymentTerms: NullableStringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  payments: SupplierPaymentUpdateManyWithoutSupplierNestedInput
-  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
-  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
-  quotes: SupplierQuoteUpdateManyWithoutSupplierNestedInput
-  user: UserUpdateOneWithoutSupplierNestedInput
-}
-
-input SupplierPaymentUpdateManyWithoutSupplierNestedInput {
-  create: [SupplierPaymentCreateWithoutSupplierInput!]
-  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutSupplierInput!]
-  upsert: [SupplierPaymentUpsertWithWhereUniqueWithoutSupplierInput!]
-  createMany: SupplierPaymentCreateManySupplierInputEnvelope
-  set: [SupplierPaymentWhereUniqueInput!]
-  disconnect: [SupplierPaymentWhereUniqueInput!]
-  delete: [SupplierPaymentWhereUniqueInput!]
-  connect: [SupplierPaymentWhereUniqueInput!]
-  update: [SupplierPaymentUpdateWithWhereUniqueWithoutSupplierInput!]
-  updateMany: [SupplierPaymentUpdateManyWithWhereWithoutSupplierInput!]
-  deleteMany: [SupplierPaymentScalarWhereInput!]
-}
-
-input SupplierPaymentUpsertWithWhereUniqueWithoutSupplierInput {
-  where: SupplierPaymentWhereUniqueInput!
-  update: SupplierPaymentUpdateWithoutSupplierInput!
-  create: SupplierPaymentCreateWithoutSupplierInput!
-}
-
-input SupplierPaymentUpdateWithoutSupplierInput {
-  id: StringFieldUpdateOperationsInput
-  amount: FloatFieldUpdateOperationsInput
-  paymentDate: DateTimeFieldUpdateOperationsInput
-  method: StringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  purchaseOrder: PurchaseOrderUpdateOneWithoutPaymentsNestedInput
-}
-
-input PurchaseOrderUpdateOneWithoutPaymentsNestedInput {
-  create: PurchaseOrderCreateWithoutPaymentsInput
-  connectOrCreate: PurchaseOrderCreateOrConnectWithoutPaymentsInput
-  upsert: PurchaseOrderUpsertWithoutPaymentsInput
-  disconnect: PurchaseOrderWhereInput
-  delete: PurchaseOrderWhereInput
-  connect: PurchaseOrderWhereUniqueInput
-  update: PurchaseOrderUpdateToOneWithWhereWithoutPaymentsInput
-}
-
-input PurchaseOrderUpsertWithoutPaymentsInput {
-  update: PurchaseOrderUpdateWithoutPaymentsInput!
-  create: PurchaseOrderCreateWithoutPaymentsInput!
-  where: PurchaseOrderWhereInput
-}
-
-input PurchaseOrderUpdateWithoutPaymentsInput {
-  id: StringFieldUpdateOperationsInput
-  invoiceNumber: StringFieldUpdateOperationsInput
-  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
-  phase: EnumPurchasePhaseFieldUpdateOperationsInput
-  dueDate: DateTimeFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
-  items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
-  receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
-}
-
-input StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput {
-  create: [StockReceiptBatchCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput!]
-  upsert: [StockReceiptBatchUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
-  set: [StockReceiptBatchWhereUniqueInput!]
-  disconnect: [StockReceiptBatchWhereUniqueInput!]
-  delete: [StockReceiptBatchWhereUniqueInput!]
-  connect: [StockReceiptBatchWhereUniqueInput!]
-  update: [StockReceiptBatchUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
-  updateMany: [StockReceiptBatchUpdateManyWithWhereWithoutPurchaseOrderInput!]
-  deleteMany: [StockReceiptBatchScalarWhereInput!]
-}
-
-input StockReceiptBatchUpsertWithWhereUniqueWithoutPurchaseOrderInput {
-  where: StockReceiptBatchWhereUniqueInput!
-  update: StockReceiptBatchUpdateWithoutPurchaseOrderInput!
-  create: StockReceiptBatchCreateWithoutPurchaseOrderInput!
-}
-
-input StockReceiptBatchUpdateWithoutPurchaseOrderInput {
-  id: StringFieldUpdateOperationsInput
-  purchaseOrderId: StringFieldUpdateOperationsInput
-  waybillUrl: NullableStringFieldUpdateOperationsInput
-  receivedAt: DateTimeFieldUpdateOperationsInput
-  store: StoreUpdateOneRequiredWithoutReceiptsNestedInput
-  receivedBy: UserUpdateOneRequiredWithoutStockReceiptBatchReceivedBysNestedInput
-  confirmedBy: UserUpdateOneRequiredWithoutStockReceiptBatchConfirmedBysNestedInput
-  items: StockReceiptBatchItemUpdateManyWithoutBatchNestedInput
-  purchaseReturns: PurchaseReturnItemUpdateManyWithoutBatchNestedInput
-}
-
-input PurchaseReturnItemUpdateManyWithoutBatchNestedInput {
-  create: [PurchaseReturnItemCreateWithoutBatchInput!]
-  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutBatchInput!]
-  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutBatchInput!]
-  createMany: PurchaseReturnItemCreateManyBatchInputEnvelope
-  set: [PurchaseReturnItemWhereUniqueInput!]
-  disconnect: [PurchaseReturnItemWhereUniqueInput!]
-  delete: [PurchaseReturnItemWhereUniqueInput!]
-  connect: [PurchaseReturnItemWhereUniqueInput!]
-  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutBatchInput!]
-  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutBatchInput!]
-  deleteMany: [PurchaseReturnItemScalarWhereInput!]
-}
-
-input PurchaseReturnItemUpsertWithWhereUniqueWithoutBatchInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  update: PurchaseReturnItemUpdateWithoutBatchInput!
-  create: PurchaseReturnItemCreateWithoutBatchInput!
-}
-
-input PurchaseReturnItemUpdateWithoutBatchInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  return: PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput
-  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput
-}
-
-input PurchaseReturnItemUpdateWithWhereUniqueWithoutBatchInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  data: PurchaseReturnItemUpdateWithoutBatchInput!
-}
-
-input PurchaseReturnItemUpdateManyWithWhereWithoutBatchInput {
-  where: PurchaseReturnItemScalarWhereInput!
-  data: PurchaseReturnItemUpdateManyMutationInput!
-}
-
-input PurchaseReturnItemScalarWhereInput {
-  AND: [PurchaseReturnItemScalarWhereInput!]
-  OR: [PurchaseReturnItemScalarWhereInput!]
-  NOT: [PurchaseReturnItemScalarWhereInput!]
-  id: StringFilter
-  purchaseReturnId: StringFilter
-  productVariantId: StringFilter
-  batchId: StringFilter
-  quantity: IntFilter
-}
-
-input PurchaseReturnItemUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-}
-
-input StockReceiptBatchUpdateWithWhereUniqueWithoutPurchaseOrderInput {
-  where: StockReceiptBatchWhereUniqueInput!
-  data: StockReceiptBatchUpdateWithoutPurchaseOrderInput!
-}
-
-input StockReceiptBatchUpdateManyWithWhereWithoutPurchaseOrderInput {
-  where: StockReceiptBatchScalarWhereInput!
-  data: StockReceiptBatchUpdateManyMutationInput!
-}
-
-input StockReceiptBatchScalarWhereInput {
-  AND: [StockReceiptBatchScalarWhereInput!]
-  OR: [StockReceiptBatchScalarWhereInput!]
-  NOT: [StockReceiptBatchScalarWhereInput!]
-  id: StringFilter
-  purchaseOrderId: StringFilter
-  storeId: StringFilter
-  receivedById: StringFilter
-  confirmedById: StringFilter
-  waybillUrl: StringNullableFilter
-  receivedAt: DateTimeFilter
-}
-
-input StockReceiptBatchUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  purchaseOrderId: StringFieldUpdateOperationsInput
-  waybillUrl: NullableStringFieldUpdateOperationsInput
-  receivedAt: DateTimeFieldUpdateOperationsInput
-}
-
-input PurchaseOrderUpdateToOneWithWhereWithoutPaymentsInput {
-  where: PurchaseOrderWhereInput
-  data: PurchaseOrderUpdateWithoutPaymentsInput!
-}
-
-input SupplierPaymentUpdateWithWhereUniqueWithoutSupplierInput {
-  where: SupplierPaymentWhereUniqueInput!
-  data: SupplierPaymentUpdateWithoutSupplierInput!
-}
-
-input SupplierPaymentUpdateManyWithWhereWithoutSupplierInput {
-  where: SupplierPaymentScalarWhereInput!
-  data: SupplierPaymentUpdateManyMutationInput!
-}
-
-input SupplierPaymentScalarWhereInput {
-  AND: [SupplierPaymentScalarWhereInput!]
-  OR: [SupplierPaymentScalarWhereInput!]
-  NOT: [SupplierPaymentScalarWhereInput!]
-  id: StringFilter
-  supplierId: StringFilter
-  purchaseOrderId: StringNullableFilter
-  amount: FloatFilter
-  paymentDate: DateTimeFilter
-  method: StringFilter
-  notes: StringNullableFilter
-}
-
-input SupplierPaymentUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  amount: FloatFieldUpdateOperationsInput
-  paymentDate: DateTimeFieldUpdateOperationsInput
-  method: StringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-}
-
-input PurchaseReturnUpdateManyWithoutSupplierNestedInput {
-  create: [PurchaseReturnCreateWithoutSupplierInput!]
-  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutSupplierInput!]
-  upsert: [PurchaseReturnUpsertWithWhereUniqueWithoutSupplierInput!]
-  createMany: PurchaseReturnCreateManySupplierInputEnvelope
-  set: [PurchaseReturnWhereUniqueInput!]
-  disconnect: [PurchaseReturnWhereUniqueInput!]
-  delete: [PurchaseReturnWhereUniqueInput!]
-  connect: [PurchaseReturnWhereUniqueInput!]
-  update: [PurchaseReturnUpdateWithWhereUniqueWithoutSupplierInput!]
-  updateMany: [PurchaseReturnUpdateManyWithWhereWithoutSupplierInput!]
-  deleteMany: [PurchaseReturnScalarWhereInput!]
-}
-
-input PurchaseReturnUpsertWithWhereUniqueWithoutSupplierInput {
-  where: PurchaseReturnWhereUniqueInput!
-  update: PurchaseReturnUpdateWithoutSupplierInput!
-  create: PurchaseReturnCreateWithoutSupplierInput!
-}
-
-input PurchaseReturnUpdateWithoutSupplierInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumReturnStatusFieldUpdateOperationsInput
-  reason: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  initiatedBy: UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput
-  approvedBy: UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput
-  items: PurchaseReturnItemUpdateManyWithoutReturnNestedInput
-}
-
-input UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput {
-  create: UserCreateWithoutPurchaseReturnApproversInput
-  connectOrCreate: UserCreateOrConnectWithoutPurchaseReturnApproversInput
-  upsert: UserUpsertWithoutPurchaseReturnApproversInput
-  connect: UserWhereUniqueInput
-  update: UserUpdateToOneWithWhereWithoutPurchaseReturnApproversInput
-}
-
-input UserUpsertWithoutPurchaseReturnApproversInput {
-  update: UserUpdateWithoutPurchaseReturnApproversInput!
-  create: UserCreateWithoutPurchaseReturnApproversInput!
-  where: UserWhereInput
-}
-
-input UserUpdateWithoutPurchaseReturnApproversInput {
-  id: StringFieldUpdateOperationsInput
-  email: StringFieldUpdateOperationsInput
-  passwordHash: StringFieldUpdateOperationsInput
-  tier: NullableEnumUserTierFieldUpdateOperationsInput
-  referralCode: NullableStringFieldUpdateOperationsInput
-  referredBy: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  isEmailVerified: BoolFieldUpdateOperationsInput
-  emailVerificationToken: NullableStringFieldUpdateOperationsInput
-  emailVerificationTokenExpiry: NullableDateTimeFieldUpdateOperationsInput
-  role: RoleUpdateOneRequiredWithoutUsersNestedInput
-  resellerProfile: ResellerProfileUpdateOneWithoutUserNestedInput
-  customerProfile: CustomerProfileUpdateOneWithoutUserNestedInput
-  resellerPaymentsMade: ResellerPaymentUpdateManyWithoutResellerNestedInput
-  resellerPaymentsReceived: ResellerPaymentUpdateManyWithoutReceivedByNestedInput
-  adminLogs: AdminActionLogUpdateManyWithoutAdminNestedInput
-  supportMessages: SupportMessageUpdateManyWithoutUserNestedInput
-  ConsumerSale: ConsumerSaleUpdateManyWithoutBillerNestedInput
-  ConsumerSaleAdjustedBys: ConsumerSaleUpdateManyWithoutAdjustedByNestedInput
-  StockReceiptBatchReceivedBys: StockReceiptBatchUpdateManyWithoutReceivedByNestedInput
-  StockReceiptBatchConfirmedBys: StockReceiptBatchUpdateManyWithoutConfirmedByNestedInput
-  StockTransferRequests: StockTransferUpdateManyWithoutRequestedByNestedInput
-  StockTransferApprovals: StockTransferUpdateManyWithoutApprovedByNestedInput
-  Store: StoreUpdateManyWithoutManagerNestedInput
-  ConsumerReceipt: ConsumerReceiptUpdateManyWithoutIssuedByNestedInput
-  ResellerSales: ResellerSaleUpdateManyWithoutResellerNestedInput
-  BillerResellerSale: ResellerSaleUpdateManyWithoutBillerNestedInput
-  ResellerSale: ResellerSaleUpdateManyWithoutApprovedByNestedInput
-  SalesReturnReceivers: SalesReturnUpdateManyWithoutReceivedByNestedInput
-  SalesReturnRequesters: SalesReturnUpdateManyWithoutReturnedByNestedInput
-  SalesReturn: SalesReturnUpdateManyWithoutApprovedByNestedInput
-  PurchaseReturnInitiators: PurchaseReturnUpdateManyWithoutInitiatedByNestedInput
   Payment: PaymentUpdateManyWithoutReceivedByNestedInput
   ResellerTierHistory: ResellerTierHistoryUpdateManyWithoutUserNestedInput
   ResellerTierHistoryChangedBys: ResellerTierHistoryUpdateManyWithoutAdminNestedInput
@@ -18348,23 +18226,141 @@ input QuotationUpdateWithoutSaleOrderInput {
   ConsumerSale: ConsumerSaleUpdateManyWithoutQuotationNestedInput
 }
 
-input UserUpdateOneWithoutResellerQuotationNestedInput {
-  create: UserCreateWithoutResellerQuotationInput
-  connectOrCreate: UserCreateOrConnectWithoutResellerQuotationInput
-  upsert: UserUpsertWithoutResellerQuotationInput
-  disconnect: UserWhereInput
-  delete: UserWhereInput
-  connect: UserWhereUniqueInput
-  update: UserUpdateToOneWithWhereWithoutResellerQuotationInput
+input QuotationItemUpdateManyWithoutQuotationNestedInput {
+  create: [QuotationItemCreateWithoutQuotationInput!]
+  connectOrCreate: [QuotationItemCreateOrConnectWithoutQuotationInput!]
+  upsert: [QuotationItemUpsertWithWhereUniqueWithoutQuotationInput!]
+  createMany: QuotationItemCreateManyQuotationInputEnvelope
+  set: [QuotationItemWhereUniqueInput!]
+  disconnect: [QuotationItemWhereUniqueInput!]
+  delete: [QuotationItemWhereUniqueInput!]
+  connect: [QuotationItemWhereUniqueInput!]
+  update: [QuotationItemUpdateWithWhereUniqueWithoutQuotationInput!]
+  updateMany: [QuotationItemUpdateManyWithWhereWithoutQuotationInput!]
+  deleteMany: [QuotationItemScalarWhereInput!]
 }
 
-input UserUpsertWithoutResellerQuotationInput {
-  update: UserUpdateWithoutResellerQuotationInput!
-  create: UserCreateWithoutResellerQuotationInput!
+input QuotationItemUpsertWithWhereUniqueWithoutQuotationInput {
+  where: QuotationItemWhereUniqueInput!
+  update: QuotationItemUpdateWithoutQuotationInput!
+  create: QuotationItemCreateWithoutQuotationInput!
+}
+
+input QuotationItemUpdateWithoutQuotationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  unitPrice: FloatFieldUpdateOperationsInput
+  productVariant: ProductVariantUpdateOneRequiredWithoutQuotationItemsNestedInput
+}
+
+input ProductVariantUpdateOneRequiredWithoutQuotationItemsNestedInput {
+  create: ProductVariantCreateWithoutQuotationItemsInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutQuotationItemsInput
+  upsert: ProductVariantUpsertWithoutQuotationItemsInput
+  connect: ProductVariantWhereUniqueInput
+  update: ProductVariantUpdateToOneWithWhereWithoutQuotationItemsInput
+}
+
+input ProductVariantUpsertWithoutQuotationItemsInput {
+  update: ProductVariantUpdateWithoutQuotationItemsInput!
+  create: ProductVariantCreateWithoutQuotationItemsInput!
+  where: ProductVariantWhereInput
+}
+
+input ProductVariantUpdateWithoutQuotationItemsInput {
+  id: StringFieldUpdateOperationsInput
+  size: StringFieldUpdateOperationsInput
+  concentration: StringFieldUpdateOperationsInput
+  packaging: StringFieldUpdateOperationsInput
+  barcode: NullableStringFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
+  resellerPrice: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
+  stockItems: StockUpdateManyWithoutProductVariantNestedInput
+  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
+  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
+  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
+  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
+  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
+  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
+  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
+  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
+  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
+  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
+  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
+}
+
+input PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput {
+  create: [PurchaseReturnItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: PurchaseReturnItemCreateManyProductVariantInputEnvelope
+  set: [PurchaseReturnItemWhereUniqueInput!]
+  disconnect: [PurchaseReturnItemWhereUniqueInput!]
+  delete: [PurchaseReturnItemWhereUniqueInput!]
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [PurchaseReturnItemScalarWhereInput!]
+}
+
+input PurchaseReturnItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  update: PurchaseReturnItemUpdateWithoutProductVariantInput!
+  create: PurchaseReturnItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseReturnItemUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  return: PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput
+  batch: StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput
+}
+
+input PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput {
+  create: PurchaseReturnCreateWithoutItemsInput
+  connectOrCreate: PurchaseReturnCreateOrConnectWithoutItemsInput
+  upsert: PurchaseReturnUpsertWithoutItemsInput
+  connect: PurchaseReturnWhereUniqueInput
+  update: PurchaseReturnUpdateToOneWithWhereWithoutItemsInput
+}
+
+input PurchaseReturnUpsertWithoutItemsInput {
+  update: PurchaseReturnUpdateWithoutItemsInput!
+  create: PurchaseReturnCreateWithoutItemsInput!
+  where: PurchaseReturnWhereInput
+}
+
+input PurchaseReturnUpdateWithoutItemsInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumReturnStatusFieldUpdateOperationsInput
+  reason: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutReturnsNestedInput
+  initiatedBy: UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput
+  approvedBy: UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput
+}
+
+input UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput {
+  create: UserCreateWithoutPurchaseReturnApproversInput
+  connectOrCreate: UserCreateOrConnectWithoutPurchaseReturnApproversInput
+  upsert: UserUpsertWithoutPurchaseReturnApproversInput
+  connect: UserWhereUniqueInput
+  update: UserUpdateToOneWithWhereWithoutPurchaseReturnApproversInput
+}
+
+input UserUpsertWithoutPurchaseReturnApproversInput {
+  update: UserUpdateWithoutPurchaseReturnApproversInput!
+  create: UserCreateWithoutPurchaseReturnApproversInput!
   where: UserWhereInput
 }
 
-input UserUpdateWithoutResellerQuotationInput {
+input UserUpdateWithoutPurchaseReturnApproversInput {
   id: StringFieldUpdateOperationsInput
   email: StringFieldUpdateOperationsInput
   passwordHash: StringFieldUpdateOperationsInput
@@ -18398,7 +18394,6 @@ input UserUpdateWithoutResellerQuotationInput {
   SalesReturnRequesters: SalesReturnUpdateManyWithoutReturnedByNestedInput
   SalesReturn: SalesReturnUpdateManyWithoutApprovedByNestedInput
   PurchaseReturnInitiators: PurchaseReturnUpdateManyWithoutInitiatedByNestedInput
-  PurchaseReturnApprovers: PurchaseReturnUpdateManyWithoutApprovedByNestedInput
   Payment: PaymentUpdateManyWithoutReceivedByNestedInput
   ResellerTierHistory: ResellerTierHistoryUpdateManyWithoutUserNestedInput
   ResellerTierHistoryChangedBys: ResellerTierHistoryUpdateManyWithoutAdminNestedInput
@@ -18406,6 +18401,7 @@ input UserUpdateWithoutResellerQuotationInput {
   Notification: NotificationUpdateManyWithoutUserNestedInput
   Fulfillment: FulfillmentUpdateManyWithoutDeliveryPersonnelNestedInput
   BillerQuotation: QuotationUpdateManyWithoutBillerNestedInput
+  ResellerQuotation: QuotationUpdateManyWithoutResellerNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutRequestedByNestedInput
   Supplier: SupplierUpdateManyWithoutUserNestedInput
 }
@@ -18527,379 +18523,6 @@ input QuotationUpdateWithoutBillerInput {
   createdAt: DateTimeFieldUpdateOperationsInput
   updatedAt: DateTimeFieldUpdateOperationsInput
   store: StoreUpdateOneRequiredWithoutQuotationNestedInput
-  consumer: CustomerUpdateOneWithoutQuotationNestedInput
-  reseller: UserUpdateOneWithoutResellerQuotationNestedInput
-  items: QuotationItemUpdateManyWithoutQuotationNestedInput
-  sale: ResellerSaleUpdateOneWithoutQuotationNestedInput
-  SaleOrder: SaleOrderUpdateOneWithoutQuotationNestedInput
-  ConsumerSale: ConsumerSaleUpdateManyWithoutQuotationNestedInput
-}
-
-input QuotationItemUpdateManyWithoutQuotationNestedInput {
-  create: [QuotationItemCreateWithoutQuotationInput!]
-  connectOrCreate: [QuotationItemCreateOrConnectWithoutQuotationInput!]
-  upsert: [QuotationItemUpsertWithWhereUniqueWithoutQuotationInput!]
-  createMany: QuotationItemCreateManyQuotationInputEnvelope
-  set: [QuotationItemWhereUniqueInput!]
-  disconnect: [QuotationItemWhereUniqueInput!]
-  delete: [QuotationItemWhereUniqueInput!]
-  connect: [QuotationItemWhereUniqueInput!]
-  update: [QuotationItemUpdateWithWhereUniqueWithoutQuotationInput!]
-  updateMany: [QuotationItemUpdateManyWithWhereWithoutQuotationInput!]
-  deleteMany: [QuotationItemScalarWhereInput!]
-}
-
-input QuotationItemUpsertWithWhereUniqueWithoutQuotationInput {
-  where: QuotationItemWhereUniqueInput!
-  update: QuotationItemUpdateWithoutQuotationInput!
-  create: QuotationItemCreateWithoutQuotationInput!
-}
-
-input QuotationItemUpdateWithoutQuotationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  unitPrice: FloatFieldUpdateOperationsInput
-  productVariant: ProductVariantUpdateOneRequiredWithoutQuotationItemsNestedInput
-}
-
-input ProductVariantUpdateOneRequiredWithoutQuotationItemsNestedInput {
-  create: ProductVariantCreateWithoutQuotationItemsInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutQuotationItemsInput
-  upsert: ProductVariantUpsertWithoutQuotationItemsInput
-  connect: ProductVariantWhereUniqueInput
-  update: ProductVariantUpdateToOneWithWhereWithoutQuotationItemsInput
-}
-
-input ProductVariantUpsertWithoutQuotationItemsInput {
-  update: ProductVariantUpdateWithoutQuotationItemsInput!
-  create: ProductVariantCreateWithoutQuotationItemsInput!
-  where: ProductVariantWhereInput
-}
-
-input ProductVariantUpdateWithoutQuotationItemsInput {
-  id: StringFieldUpdateOperationsInput
-  size: StringFieldUpdateOperationsInput
-  concentration: StringFieldUpdateOperationsInput
-  packaging: StringFieldUpdateOperationsInput
-  barcode: NullableStringFieldUpdateOperationsInput
-  price: FloatFieldUpdateOperationsInput
-  resellerPrice: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
-  stockItems: StockUpdateManyWithoutProductVariantNestedInput
-  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
-  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
-  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
-  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
-  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
-  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
-  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
-  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
-  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
-  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
-  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
-}
-
-input StockMovementItemUpdateManyWithoutProductVariantNestedInput {
-  create: [StockMovementItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [StockMovementItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [StockMovementItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: StockMovementItemCreateManyProductVariantInputEnvelope
-  set: [StockMovementItemWhereUniqueInput!]
-  disconnect: [StockMovementItemWhereUniqueInput!]
-  delete: [StockMovementItemWhereUniqueInput!]
-  connect: [StockMovementItemWhereUniqueInput!]
-  update: [StockMovementItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [StockMovementItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [StockMovementItemScalarWhereInput!]
-}
-
-input StockMovementItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: StockMovementItemWhereUniqueInput!
-  update: StockMovementItemUpdateWithoutProductVariantInput!
-  create: StockMovementItemCreateWithoutProductVariantInput!
-}
-
-input StockMovementItemUpdateWithoutProductVariantInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  movement: StockMovementUpdateOneRequiredWithoutItemsNestedInput
-}
-
-input StockMovementUpdateOneRequiredWithoutItemsNestedInput {
-  create: StockMovementCreateWithoutItemsInput
-  connectOrCreate: StockMovementCreateOrConnectWithoutItemsInput
-  upsert: StockMovementUpsertWithoutItemsInput
-  connect: StockMovementWhereUniqueInput
-  update: StockMovementUpdateToOneWithWhereWithoutItemsInput
-}
-
-input StockMovementUpsertWithoutItemsInput {
-  update: StockMovementUpdateWithoutItemsInput!
-  create: StockMovementCreateWithoutItemsInput!
-  where: StockMovementWhereInput
-}
-
-input StockMovementUpdateWithoutItemsInput {
-  id: StringFieldUpdateOperationsInput
-  direction: EnumMovementDirectionFieldUpdateOperationsInput
-  movementType: EnumMovementTypeFieldUpdateOperationsInput
-  referenceEntity: StringFieldUpdateOperationsInput
-  referenceId: StringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  store: StoreUpdateOneRequiredWithoutMovementsNestedInput
-}
-
-input StoreUpdateOneRequiredWithoutMovementsNestedInput {
-  create: StoreCreateWithoutMovementsInput
-  connectOrCreate: StoreCreateOrConnectWithoutMovementsInput
-  upsert: StoreUpsertWithoutMovementsInput
-  connect: StoreWhereUniqueInput
-  update: StoreUpdateToOneWithWhereWithoutMovementsInput
-}
-
-input StoreUpsertWithoutMovementsInput {
-  update: StoreUpdateWithoutMovementsInput!
-  create: StoreCreateWithoutMovementsInput!
-  where: StoreWhereInput
-}
-
-input StoreUpdateWithoutMovementsInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-  location: NullableStringFieldUpdateOperationsInput
-  isMain: BoolFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  manager: UserUpdateOneRequiredWithoutStoreNestedInput
-  stocks: StockUpdateManyWithoutStoreNestedInput
-  receipts: StockReceiptBatchUpdateManyWithoutStoreNestedInput
-  transfersOut: StockTransferUpdateManyWithoutFromStoreNestedInput
-  transfersIn: StockTransferUpdateManyWithoutToStoreNestedInput
-  customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
-  salesReturns: SalesReturnUpdateManyWithoutStoreNestedInput
-  resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
-  Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
-  CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
-  Quotation: QuotationUpdateManyWithoutStoreNestedInput
-  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
-}
-
-input CustomerProfileUpdateManyWithoutPreferredStoreNestedInput {
-  create: [CustomerProfileCreateWithoutPreferredStoreInput!]
-  connectOrCreate: [CustomerProfileCreateOrConnectWithoutPreferredStoreInput!]
-  upsert: [CustomerProfileUpsertWithWhereUniqueWithoutPreferredStoreInput!]
-  createMany: CustomerProfileCreateManyPreferredStoreInputEnvelope
-  set: [CustomerProfileWhereUniqueInput!]
-  disconnect: [CustomerProfileWhereUniqueInput!]
-  delete: [CustomerProfileWhereUniqueInput!]
-  connect: [CustomerProfileWhereUniqueInput!]
-  update: [CustomerProfileUpdateWithWhereUniqueWithoutPreferredStoreInput!]
-  updateMany: [CustomerProfileUpdateManyWithWhereWithoutPreferredStoreInput!]
-  deleteMany: [CustomerProfileScalarWhereInput!]
-}
-
-input CustomerProfileUpsertWithWhereUniqueWithoutPreferredStoreInput {
-  where: CustomerProfileWhereUniqueInput!
-  update: CustomerProfileUpdateWithoutPreferredStoreInput!
-  create: CustomerProfileCreateWithoutPreferredStoreInput!
-}
-
-input CustomerProfileUpdateWithoutPreferredStoreInput {
-  fullName: StringFieldUpdateOperationsInput
-  phone: NullableStringFieldUpdateOperationsInput
-  email: NullableStringFieldUpdateOperationsInput
-  gender: NullableStringFieldUpdateOperationsInput
-  birthday: NullableDateTimeFieldUpdateOperationsInput
-  profileStatus: EnumProfileStatusFieldUpdateOperationsInput
-  requestedAt: DateTimeFieldUpdateOperationsInput
-  activatedAt: NullableDateTimeFieldUpdateOperationsInput
-  isPhoneVerified: BoolFieldUpdateOperationsInput
-  phoneVerificationCode: NullableStringFieldUpdateOperationsInput
-  phoneVerificationCodeExpiry: NullableDateTimeFieldUpdateOperationsInput
-  user: UserUpdateOneRequiredWithoutCustomerProfileNestedInput
-  referredBy: CustomerProfileUpdateOneWithoutReferralsNestedInput
-  referrals: CustomerProfileUpdateManyWithoutReferredByNestedInput
-  sales: ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput
-  preferences: CustomerPreferenceProfileUpdateOneWithoutCustomerProfileNestedInput
-}
-
-input CustomerProfileUpdateOneWithoutReferralsNestedInput {
-  create: CustomerProfileCreateWithoutReferralsInput
-  connectOrCreate: CustomerProfileCreateOrConnectWithoutReferralsInput
-  upsert: CustomerProfileUpsertWithoutReferralsInput
-  disconnect: CustomerProfileWhereInput
-  delete: CustomerProfileWhereInput
-  connect: CustomerProfileWhereUniqueInput
-  update: CustomerProfileUpdateToOneWithWhereWithoutReferralsInput
-}
-
-input CustomerProfileUpsertWithoutReferralsInput {
-  update: CustomerProfileUpdateWithoutReferralsInput!
-  create: CustomerProfileCreateWithoutReferralsInput!
-  where: CustomerProfileWhereInput
-}
-
-input CustomerProfileUpdateWithoutReferralsInput {
-  fullName: StringFieldUpdateOperationsInput
-  phone: NullableStringFieldUpdateOperationsInput
-  email: NullableStringFieldUpdateOperationsInput
-  gender: NullableStringFieldUpdateOperationsInput
-  birthday: NullableDateTimeFieldUpdateOperationsInput
-  profileStatus: EnumProfileStatusFieldUpdateOperationsInput
-  requestedAt: DateTimeFieldUpdateOperationsInput
-  activatedAt: NullableDateTimeFieldUpdateOperationsInput
-  isPhoneVerified: BoolFieldUpdateOperationsInput
-  phoneVerificationCode: NullableStringFieldUpdateOperationsInput
-  phoneVerificationCodeExpiry: NullableDateTimeFieldUpdateOperationsInput
-  user: UserUpdateOneRequiredWithoutCustomerProfileNestedInput
-  preferredStore: StoreUpdateOneWithoutCustomerProfileNestedInput
-  referredBy: CustomerProfileUpdateOneWithoutReferralsNestedInput
-  sales: ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput
-  preferences: CustomerPreferenceProfileUpdateOneWithoutCustomerProfileNestedInput
-}
-
-input ConsumerSaleUpdateManyWithoutCustomerProfileNestedInput {
-  create: [ConsumerSaleCreateWithoutCustomerProfileInput!]
-  connectOrCreate: [ConsumerSaleCreateOrConnectWithoutCustomerProfileInput!]
-  upsert: [ConsumerSaleUpsertWithWhereUniqueWithoutCustomerProfileInput!]
-  set: [ConsumerSaleWhereUniqueInput!]
-  disconnect: [ConsumerSaleWhereUniqueInput!]
-  delete: [ConsumerSaleWhereUniqueInput!]
-  connect: [ConsumerSaleWhereUniqueInput!]
-  update: [ConsumerSaleUpdateWithWhereUniqueWithoutCustomerProfileInput!]
-  updateMany: [ConsumerSaleUpdateManyWithWhereWithoutCustomerProfileInput!]
-  deleteMany: [ConsumerSaleScalarWhereInput!]
-}
-
-input ConsumerSaleUpsertWithWhereUniqueWithoutCustomerProfileInput {
-  where: ConsumerSaleWhereUniqueInput!
-  update: ConsumerSaleUpdateWithoutCustomerProfileInput!
-  create: ConsumerSaleCreateWithoutCustomerProfileInput!
-}
-
-input ConsumerSaleUpdateWithoutCustomerProfileInput {
-  id: StringFieldUpdateOperationsInput
-  channel: EnumSaleChannelFieldUpdateOperationsInput
-  status: EnumSaleStatusFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  adjustmentType: NullableEnumAdjustmentTypeFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  customer: CustomerUpdateOneWithoutSalesNestedInput
-  store: StoreUpdateOneRequiredWithoutCustomerSalesNestedInput
-  biller: UserUpdateOneRequiredWithoutConsumerSaleNestedInput
-  adjustedBy: UserUpdateOneWithoutConsumerSaleAdjustedBysNestedInput
-  quotation: QuotationUpdateOneWithoutConsumerSaleNestedInput
-  items: ConsumerSaleItemUpdateManyWithoutSaleNestedInput
-  payments: ConsumerPaymentUpdateManyWithoutSaleNestedInput
-  receipt: ConsumerReceiptUpdateOneWithoutSaleNestedInput
-  SalesReturn: SalesReturnUpdateManyWithoutConsumerSaleNestedInput
-  SaleOrder: SaleOrderUpdateOneRequiredWithoutConsumerSaleNestedInput
-}
-
-input SalesReturnUpdateManyWithoutConsumerSaleNestedInput {
-  create: [SalesReturnCreateWithoutConsumerSaleInput!]
-  connectOrCreate: [SalesReturnCreateOrConnectWithoutConsumerSaleInput!]
-  upsert: [SalesReturnUpsertWithWhereUniqueWithoutConsumerSaleInput!]
-  createMany: SalesReturnCreateManyConsumerSaleInputEnvelope
-  set: [SalesReturnWhereUniqueInput!]
-  disconnect: [SalesReturnWhereUniqueInput!]
-  delete: [SalesReturnWhereUniqueInput!]
-  connect: [SalesReturnWhereUniqueInput!]
-  update: [SalesReturnUpdateWithWhereUniqueWithoutConsumerSaleInput!]
-  updateMany: [SalesReturnUpdateManyWithWhereWithoutConsumerSaleInput!]
-  deleteMany: [SalesReturnScalarWhereInput!]
-}
-
-input SalesReturnUpsertWithWhereUniqueWithoutConsumerSaleInput {
-  where: SalesReturnWhereUniqueInput!
-  update: SalesReturnUpdateWithoutConsumerSaleInput!
-  create: SalesReturnCreateWithoutConsumerSaleInput!
-}
-
-input SalesReturnUpdateWithoutConsumerSaleInput {
-  id: StringFieldUpdateOperationsInput
-  type: EnumSaleTypeFieldUpdateOperationsInput
-  status: EnumReturnStatusFieldUpdateOperationsInput
-  returnLocation: EnumReturnLocationFieldUpdateOperationsInput
-  isApprovedLate: BoolFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  resellerSale: ResellerSaleUpdateOneWithoutSalesReturnNestedInput
-  returnedBy: UserUpdateOneRequiredWithoutSalesReturnRequestersNestedInput
-  receivedBy: UserUpdateOneRequiredWithoutSalesReturnReceiversNestedInput
-  approvedBy: UserUpdateOneWithoutSalesReturnNestedInput
-  store: StoreUpdateOneRequiredWithoutSalesReturnsNestedInput
-  items: SalesReturnItemUpdateManyWithoutReturnNestedInput
-}
-
-input StoreUpdateOneRequiredWithoutSalesReturnsNestedInput {
-  create: StoreCreateWithoutSalesReturnsInput
-  connectOrCreate: StoreCreateOrConnectWithoutSalesReturnsInput
-  upsert: StoreUpsertWithoutSalesReturnsInput
-  connect: StoreWhereUniqueInput
-  update: StoreUpdateToOneWithWhereWithoutSalesReturnsInput
-}
-
-input StoreUpsertWithoutSalesReturnsInput {
-  update: StoreUpdateWithoutSalesReturnsInput!
-  create: StoreCreateWithoutSalesReturnsInput!
-  where: StoreWhereInput
-}
-
-input StoreUpdateWithoutSalesReturnsInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-  location: NullableStringFieldUpdateOperationsInput
-  isMain: BoolFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  manager: UserUpdateOneRequiredWithoutStoreNestedInput
-  stocks: StockUpdateManyWithoutStoreNestedInput
-  receipts: StockReceiptBatchUpdateManyWithoutStoreNestedInput
-  transfersOut: StockTransferUpdateManyWithoutFromStoreNestedInput
-  transfersIn: StockTransferUpdateManyWithoutToStoreNestedInput
-  customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
-  resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
-  movements: StockMovementUpdateManyWithoutStoreNestedInput
-  Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
-  CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
-  Quotation: QuotationUpdateManyWithoutStoreNestedInput
-  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
-}
-
-input QuotationUpdateManyWithoutStoreNestedInput {
-  create: [QuotationCreateWithoutStoreInput!]
-  connectOrCreate: [QuotationCreateOrConnectWithoutStoreInput!]
-  upsert: [QuotationUpsertWithWhereUniqueWithoutStoreInput!]
-  createMany: QuotationCreateManyStoreInputEnvelope
-  set: [QuotationWhereUniqueInput!]
-  disconnect: [QuotationWhereUniqueInput!]
-  delete: [QuotationWhereUniqueInput!]
-  connect: [QuotationWhereUniqueInput!]
-  update: [QuotationUpdateWithWhereUniqueWithoutStoreInput!]
-  updateMany: [QuotationUpdateManyWithWhereWithoutStoreInput!]
-  deleteMany: [QuotationScalarWhereInput!]
-}
-
-input QuotationUpsertWithWhereUniqueWithoutStoreInput {
-  where: QuotationWhereUniqueInput!
-  update: QuotationUpdateWithoutStoreInput!
-  create: QuotationCreateWithoutStoreInput!
-}
-
-input QuotationUpdateWithoutStoreInput {
-  id: StringFieldUpdateOperationsInput
-  type: EnumSaleTypeFieldUpdateOperationsInput
-  channel: EnumSaleChannelFieldUpdateOperationsInput
-  status: EnumQuotationStatusFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  biller: UserUpdateOneWithoutBillerQuotationNestedInput
   consumer: CustomerUpdateOneWithoutQuotationNestedInput
   reseller: UserUpdateOneWithoutResellerQuotationNestedInput
   items: QuotationItemUpdateManyWithoutQuotationNestedInput
@@ -19042,78 +18665,399 @@ input ProductVariantUpdateWithoutReturnItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
-input PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput {
-  create: [PurchaseRequisitionItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [PurchaseRequisitionItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: PurchaseRequisitionItemCreateManyProductVariantInputEnvelope
-  set: [PurchaseRequisitionItemWhereUniqueInput!]
-  disconnect: [PurchaseRequisitionItemWhereUniqueInput!]
-  delete: [PurchaseRequisitionItemWhereUniqueInput!]
-  connect: [PurchaseRequisitionItemWhereUniqueInput!]
-  update: [PurchaseRequisitionItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [PurchaseRequisitionItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [PurchaseRequisitionItemScalarWhereInput!]
+input StockTransferItemUpdateManyWithoutProductVariantNestedInput {
+  create: [StockTransferItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [StockTransferItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [StockTransferItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: StockTransferItemCreateManyProductVariantInputEnvelope
+  set: [StockTransferItemWhereUniqueInput!]
+  disconnect: [StockTransferItemWhereUniqueInput!]
+  delete: [StockTransferItemWhereUniqueInput!]
+  connect: [StockTransferItemWhereUniqueInput!]
+  update: [StockTransferItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [StockTransferItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [StockTransferItemScalarWhereInput!]
 }
 
-input PurchaseRequisitionItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseRequisitionItemWhereUniqueInput!
-  update: PurchaseRequisitionItemUpdateWithoutProductVariantInput!
-  create: PurchaseRequisitionItemCreateWithoutProductVariantInput!
+input StockTransferItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: StockTransferItemWhereUniqueInput!
+  update: StockTransferItemUpdateWithoutProductVariantInput!
+  create: StockTransferItemCreateWithoutProductVariantInput!
 }
 
-input PurchaseRequisitionItemUpdateWithoutProductVariantInput {
+input StockTransferItemUpdateWithoutProductVariantInput {
   id: StringFieldUpdateOperationsInput
-  requestedQty: IntFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  requisition: PurchaseRequisitionUpdateOneRequiredWithoutItemsNestedInput
+  quantity: IntFieldUpdateOperationsInput
+  transfer: StockTransferUpdateOneRequiredWithoutItemsNestedInput
 }
 
-input PurchaseRequisitionUpdateOneRequiredWithoutItemsNestedInput {
-  create: PurchaseRequisitionCreateWithoutItemsInput
-  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutItemsInput
-  upsert: PurchaseRequisitionUpsertWithoutItemsInput
-  connect: PurchaseRequisitionWhereUniqueInput
-  update: PurchaseRequisitionUpdateToOneWithWhereWithoutItemsInput
+input StockTransferUpdateOneRequiredWithoutItemsNestedInput {
+  create: StockTransferCreateWithoutItemsInput
+  connectOrCreate: StockTransferCreateOrConnectWithoutItemsInput
+  upsert: StockTransferUpsertWithoutItemsInput
+  connect: StockTransferWhereUniqueInput
+  update: StockTransferUpdateToOneWithWhereWithoutItemsInput
 }
 
-input PurchaseRequisitionUpsertWithoutItemsInput {
-  update: PurchaseRequisitionUpdateWithoutItemsInput!
-  create: PurchaseRequisitionCreateWithoutItemsInput!
-  where: PurchaseRequisitionWhereInput
+input StockTransferUpsertWithoutItemsInput {
+  update: StockTransferUpdateWithoutItemsInput!
+  create: StockTransferCreateWithoutItemsInput!
+  where: StockTransferWhereInput
 }
 
-input PurchaseRequisitionUpdateWithoutItemsInput {
+input StockTransferUpdateWithoutItemsInput {
   id: StringFieldUpdateOperationsInput
-  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
+  status: EnumTransferStatusFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  fromStore: StoreUpdateOneRequiredWithoutTransfersOutNestedInput
+  toStore: StoreUpdateOneRequiredWithoutTransfersInNestedInput
+  requestedBy: UserUpdateOneRequiredWithoutStockTransferRequestsNestedInput
+  approvedBy: UserUpdateOneRequiredWithoutStockTransferApprovalsNestedInput
+}
+
+input StockTransferUpdateToOneWithWhereWithoutItemsInput {
+  where: StockTransferWhereInput
+  data: StockTransferUpdateWithoutItemsInput!
+}
+
+input StockTransferItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: StockTransferItemWhereUniqueInput!
+  data: StockTransferItemUpdateWithoutProductVariantInput!
+}
+
+input StockTransferItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: StockTransferItemScalarWhereInput!
+  data: StockTransferItemUpdateManyMutationInput!
+}
+
+input StockTransferItemScalarWhereInput {
+  AND: [StockTransferItemScalarWhereInput!]
+  OR: [StockTransferItemScalarWhereInput!]
+  NOT: [StockTransferItemScalarWhereInput!]
+  id: StringFilter
+  stockTransferId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+}
+
+input StockTransferItemUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+}
+
+input ProductSalesStatsUpdateOneWithoutProductVariantNestedInput {
+  create: ProductSalesStatsCreateWithoutProductVariantInput
+  connectOrCreate: ProductSalesStatsCreateOrConnectWithoutProductVariantInput
+  upsert: ProductSalesStatsUpsertWithoutProductVariantInput
+  disconnect: ProductSalesStatsWhereInput
+  delete: ProductSalesStatsWhereInput
+  connect: ProductSalesStatsWhereUniqueInput
+  update: ProductSalesStatsUpdateToOneWithWhereWithoutProductVariantInput
+}
+
+input ProductSalesStatsUpsertWithoutProductVariantInput {
+  update: ProductSalesStatsUpdateWithoutProductVariantInput!
+  create: ProductSalesStatsCreateWithoutProductVariantInput!
+  where: ProductSalesStatsWhereInput
+}
+
+input ProductSalesStatsUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  totalSold: IntFieldUpdateOperationsInput
+  totalReturned: IntFieldUpdateOperationsInput
+  lastSoldAt: NullableDateTimeFieldUpdateOperationsInput
+  monthlySales: JSON
+}
+
+input ProductSalesStatsUpdateToOneWithWhereWithoutProductVariantInput {
+  where: ProductSalesStatsWhereInput
+  data: ProductSalesStatsUpdateWithoutProductVariantInput!
+}
+
+input PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput {
+  create: [PurchaseOrderItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [PurchaseOrderItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: PurchaseOrderItemCreateManyProductVariantInputEnvelope
+  set: [PurchaseOrderItemWhereUniqueInput!]
+  disconnect: [PurchaseOrderItemWhereUniqueInput!]
+  delete: [PurchaseOrderItemWhereUniqueInput!]
+  connect: [PurchaseOrderItemWhereUniqueInput!]
+  update: [PurchaseOrderItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [PurchaseOrderItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [PurchaseOrderItemScalarWhereInput!]
+}
+
+input PurchaseOrderItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  update: PurchaseOrderItemUpdateWithoutProductVariantInput!
+  create: PurchaseOrderItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseOrderItemUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  unitCost: FloatFieldUpdateOperationsInput
+  purchaseOrder: PurchaseOrderUpdateOneRequiredWithoutItemsNestedInput
+}
+
+input PurchaseOrderUpdateOneRequiredWithoutItemsNestedInput {
+  create: PurchaseOrderCreateWithoutItemsInput
+  connectOrCreate: PurchaseOrderCreateOrConnectWithoutItemsInput
+  upsert: PurchaseOrderUpsertWithoutItemsInput
+  connect: PurchaseOrderWhereUniqueInput
+  update: PurchaseOrderUpdateToOneWithWhereWithoutItemsInput
+}
+
+input PurchaseOrderUpsertWithoutItemsInput {
+  update: PurchaseOrderUpdateWithoutItemsInput!
+  create: PurchaseOrderCreateWithoutItemsInput!
+  where: PurchaseOrderWhereInput
+}
+
+input PurchaseOrderUpdateWithoutItemsInput {
+  id: StringFieldUpdateOperationsInput
+  invoiceNumber: StringFieldUpdateOperationsInput
+  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
+  phase: EnumPurchasePhaseFieldUpdateOperationsInput
+  dueDate: DateTimeFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
   createdAt: DateTimeFieldUpdateOperationsInput
   updatedAt: DateTimeFieldUpdateOperationsInput
-  store: StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
-  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
-  quotes: SupplierQuoteUpdateManyWithoutRequisitionNestedInput
+  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
+  store: StoreUpdateOneWithoutPurchaseOrdersNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
+  payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
 }
 
-input EnumPurchaseRequisitionStatusFieldUpdateOperationsInput {
-  set: PurchaseRequisitionStatus
+input SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput {
+  create: SupplierCreateWithoutPurchaseOrdersInput
+  connectOrCreate: SupplierCreateOrConnectWithoutPurchaseOrdersInput
+  upsert: SupplierUpsertWithoutPurchaseOrdersInput
+  connect: SupplierWhereUniqueInput
+  update: SupplierUpdateToOneWithWhereWithoutPurchaseOrdersInput
 }
 
-input StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput {
-  create: StoreCreateWithoutPurchaseRequisitionInput
-  connectOrCreate: StoreCreateOrConnectWithoutPurchaseRequisitionInput
-  upsert: StoreUpsertWithoutPurchaseRequisitionInput
+input SupplierUpsertWithoutPurchaseOrdersInput {
+  update: SupplierUpdateWithoutPurchaseOrdersInput!
+  create: SupplierCreateWithoutPurchaseOrdersInput!
+  where: SupplierWhereInput
+}
+
+input SupplierUpdateWithoutPurchaseOrdersInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  contactInfo: JSON
+  isFrequent: BoolFieldUpdateOperationsInput
+  creditLimit: FloatFieldUpdateOperationsInput
+  currentBalance: FloatFieldUpdateOperationsInput
+  paymentTerms: NullableStringFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  payments: SupplierPaymentUpdateManyWithoutSupplierNestedInput
+  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
+  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
+  quotes: SupplierQuoteUpdateManyWithoutSupplierNestedInput
+  user: UserUpdateOneWithoutSupplierNestedInput
+}
+
+input SupplierPaymentUpdateManyWithoutSupplierNestedInput {
+  create: [SupplierPaymentCreateWithoutSupplierInput!]
+  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutSupplierInput!]
+  upsert: [SupplierPaymentUpsertWithWhereUniqueWithoutSupplierInput!]
+  createMany: SupplierPaymentCreateManySupplierInputEnvelope
+  set: [SupplierPaymentWhereUniqueInput!]
+  disconnect: [SupplierPaymentWhereUniqueInput!]
+  delete: [SupplierPaymentWhereUniqueInput!]
+  connect: [SupplierPaymentWhereUniqueInput!]
+  update: [SupplierPaymentUpdateWithWhereUniqueWithoutSupplierInput!]
+  updateMany: [SupplierPaymentUpdateManyWithWhereWithoutSupplierInput!]
+  deleteMany: [SupplierPaymentScalarWhereInput!]
+}
+
+input SupplierPaymentUpsertWithWhereUniqueWithoutSupplierInput {
+  where: SupplierPaymentWhereUniqueInput!
+  update: SupplierPaymentUpdateWithoutSupplierInput!
+  create: SupplierPaymentCreateWithoutSupplierInput!
+}
+
+input SupplierPaymentUpdateWithoutSupplierInput {
+  id: StringFieldUpdateOperationsInput
+  amount: FloatFieldUpdateOperationsInput
+  paymentDate: DateTimeFieldUpdateOperationsInput
+  method: StringFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  purchaseOrder: PurchaseOrderUpdateOneWithoutPaymentsNestedInput
+}
+
+input PurchaseOrderUpdateOneWithoutPaymentsNestedInput {
+  create: PurchaseOrderCreateWithoutPaymentsInput
+  connectOrCreate: PurchaseOrderCreateOrConnectWithoutPaymentsInput
+  upsert: PurchaseOrderUpsertWithoutPaymentsInput
+  disconnect: PurchaseOrderWhereInput
+  delete: PurchaseOrderWhereInput
+  connect: PurchaseOrderWhereUniqueInput
+  update: PurchaseOrderUpdateToOneWithWhereWithoutPaymentsInput
+}
+
+input PurchaseOrderUpsertWithoutPaymentsInput {
+  update: PurchaseOrderUpdateWithoutPaymentsInput!
+  create: PurchaseOrderCreateWithoutPaymentsInput!
+  where: PurchaseOrderWhereInput
+}
+
+input PurchaseOrderUpdateWithoutPaymentsInput {
+  id: StringFieldUpdateOperationsInput
+  invoiceNumber: StringFieldUpdateOperationsInput
+  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
+  phase: EnumPurchasePhaseFieldUpdateOperationsInput
+  dueDate: DateTimeFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
+  store: StoreUpdateOneWithoutPurchaseOrdersNestedInput
+  items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
+}
+
+input PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput {
+  create: [PurchaseOrderItemCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [PurchaseOrderItemCreateOrConnectWithoutPurchaseOrderInput!]
+  upsert: [PurchaseOrderItemUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
+  createMany: PurchaseOrderItemCreateManyPurchaseOrderInputEnvelope
+  set: [PurchaseOrderItemWhereUniqueInput!]
+  disconnect: [PurchaseOrderItemWhereUniqueInput!]
+  delete: [PurchaseOrderItemWhereUniqueInput!]
+  connect: [PurchaseOrderItemWhereUniqueInput!]
+  update: [PurchaseOrderItemUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
+  updateMany: [PurchaseOrderItemUpdateManyWithWhereWithoutPurchaseOrderInput!]
+  deleteMany: [PurchaseOrderItemScalarWhereInput!]
+}
+
+input PurchaseOrderItemUpsertWithWhereUniqueWithoutPurchaseOrderInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  update: PurchaseOrderItemUpdateWithoutPurchaseOrderInput!
+  create: PurchaseOrderItemCreateWithoutPurchaseOrderInput!
+}
+
+input PurchaseOrderItemUpdateWithoutPurchaseOrderInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  unitCost: FloatFieldUpdateOperationsInput
+  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseOrderItemNestedInput
+}
+
+input ProductVariantUpdateOneRequiredWithoutPurchaseOrderItemNestedInput {
+  create: ProductVariantCreateWithoutPurchaseOrderItemInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseOrderItemInput
+  upsert: ProductVariantUpsertWithoutPurchaseOrderItemInput
+  connect: ProductVariantWhereUniqueInput
+  update: ProductVariantUpdateToOneWithWhereWithoutPurchaseOrderItemInput
+}
+
+input ProductVariantUpsertWithoutPurchaseOrderItemInput {
+  update: ProductVariantUpdateWithoutPurchaseOrderItemInput!
+  create: ProductVariantCreateWithoutPurchaseOrderItemInput!
+  where: ProductVariantWhereInput
+}
+
+input ProductVariantUpdateWithoutPurchaseOrderItemInput {
+  id: StringFieldUpdateOperationsInput
+  size: StringFieldUpdateOperationsInput
+  concentration: StringFieldUpdateOperationsInput
+  packaging: StringFieldUpdateOperationsInput
+  barcode: NullableStringFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
+  resellerPrice: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
+  stockItems: StockUpdateManyWithoutProductVariantNestedInput
+  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
+  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
+  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
+  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
+  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
+  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
+  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
+  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
+  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
+  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
+  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
+}
+
+input StockMovementItemUpdateManyWithoutProductVariantNestedInput {
+  create: [StockMovementItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [StockMovementItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [StockMovementItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: StockMovementItemCreateManyProductVariantInputEnvelope
+  set: [StockMovementItemWhereUniqueInput!]
+  disconnect: [StockMovementItemWhereUniqueInput!]
+  delete: [StockMovementItemWhereUniqueInput!]
+  connect: [StockMovementItemWhereUniqueInput!]
+  update: [StockMovementItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [StockMovementItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [StockMovementItemScalarWhereInput!]
+}
+
+input StockMovementItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: StockMovementItemWhereUniqueInput!
+  update: StockMovementItemUpdateWithoutProductVariantInput!
+  create: StockMovementItemCreateWithoutProductVariantInput!
+}
+
+input StockMovementItemUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  movement: StockMovementUpdateOneRequiredWithoutItemsNestedInput
+}
+
+input StockMovementUpdateOneRequiredWithoutItemsNestedInput {
+  create: StockMovementCreateWithoutItemsInput
+  connectOrCreate: StockMovementCreateOrConnectWithoutItemsInput
+  upsert: StockMovementUpsertWithoutItemsInput
+  connect: StockMovementWhereUniqueInput
+  update: StockMovementUpdateToOneWithWhereWithoutItemsInput
+}
+
+input StockMovementUpsertWithoutItemsInput {
+  update: StockMovementUpdateWithoutItemsInput!
+  create: StockMovementCreateWithoutItemsInput!
+  where: StockMovementWhereInput
+}
+
+input StockMovementUpdateWithoutItemsInput {
+  id: StringFieldUpdateOperationsInput
+  direction: EnumMovementDirectionFieldUpdateOperationsInput
+  movementType: EnumMovementTypeFieldUpdateOperationsInput
+  referenceEntity: StringFieldUpdateOperationsInput
+  referenceId: StringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneRequiredWithoutMovementsNestedInput
+}
+
+input StoreUpdateOneRequiredWithoutMovementsNestedInput {
+  create: StoreCreateWithoutMovementsInput
+  connectOrCreate: StoreCreateOrConnectWithoutMovementsInput
+  upsert: StoreUpsertWithoutMovementsInput
   connect: StoreWhereUniqueInput
-  update: StoreUpdateToOneWithWhereWithoutPurchaseRequisitionInput
+  update: StoreUpdateToOneWithWhereWithoutMovementsInput
 }
 
-input StoreUpsertWithoutPurchaseRequisitionInput {
-  update: StoreUpdateWithoutPurchaseRequisitionInput!
-  create: StoreCreateWithoutPurchaseRequisitionInput!
+input StoreUpsertWithoutMovementsInput {
+  update: StoreUpdateWithoutMovementsInput!
+  create: StoreCreateWithoutMovementsInput!
   where: StoreWhereInput
 }
 
-input StoreUpdateWithoutPurchaseRequisitionInput {
+input StoreUpdateWithoutMovementsInput {
   id: StringFieldUpdateOperationsInput
   name: StringFieldUpdateOperationsInput
   location: NullableStringFieldUpdateOperationsInput
@@ -19128,15 +19072,45 @@ input StoreUpdateWithoutPurchaseRequisitionInput {
   customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
   salesReturns: SalesReturnUpdateManyWithoutStoreNestedInput
   resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
-  movements: StockMovementUpdateManyWithoutStoreNestedInput
   Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
+  PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
-input StoreUpdateToOneWithWhereWithoutPurchaseRequisitionInput {
-  where: StoreWhereInput
-  data: StoreUpdateWithoutPurchaseRequisitionInput!
+input PurchaseRequisitionUpdateManyWithoutStoreNestedInput {
+  create: [PurchaseRequisitionCreateWithoutStoreInput!]
+  connectOrCreate: [PurchaseRequisitionCreateOrConnectWithoutStoreInput!]
+  upsert: [PurchaseRequisitionUpsertWithWhereUniqueWithoutStoreInput!]
+  createMany: PurchaseRequisitionCreateManyStoreInputEnvelope
+  set: [PurchaseRequisitionWhereUniqueInput!]
+  disconnect: [PurchaseRequisitionWhereUniqueInput!]
+  delete: [PurchaseRequisitionWhereUniqueInput!]
+  connect: [PurchaseRequisitionWhereUniqueInput!]
+  update: [PurchaseRequisitionUpdateWithWhereUniqueWithoutStoreInput!]
+  updateMany: [PurchaseRequisitionUpdateManyWithWhereWithoutStoreInput!]
+  deleteMany: [PurchaseRequisitionScalarWhereInput!]
+}
+
+input PurchaseRequisitionUpsertWithWhereUniqueWithoutStoreInput {
+  where: PurchaseRequisitionWhereUniqueInput!
+  update: PurchaseRequisitionUpdateWithoutStoreInput!
+  create: PurchaseRequisitionCreateWithoutStoreInput!
+}
+
+input PurchaseRequisitionUpdateWithoutStoreInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
+  items: PurchaseRequisitionItemUpdateManyWithoutRequisitionNestedInput
+  quotes: SupplierQuoteUpdateManyWithoutRequisitionNestedInput
+}
+
+input EnumPurchaseRequisitionStatusFieldUpdateOperationsInput {
+  set: PurchaseRequisitionStatus
 }
 
 input UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput {
@@ -19390,6 +19364,619 @@ input PurchaseRequisitionUpdateWithoutRequestedByInput {
   quotes: SupplierQuoteUpdateManyWithoutRequisitionNestedInput
 }
 
+input StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput {
+  create: StoreCreateWithoutPurchaseRequisitionInput
+  connectOrCreate: StoreCreateOrConnectWithoutPurchaseRequisitionInput
+  upsert: StoreUpsertWithoutPurchaseRequisitionInput
+  connect: StoreWhereUniqueInput
+  update: StoreUpdateToOneWithWhereWithoutPurchaseRequisitionInput
+}
+
+input StoreUpsertWithoutPurchaseRequisitionInput {
+  update: StoreUpdateWithoutPurchaseRequisitionInput!
+  create: StoreCreateWithoutPurchaseRequisitionInput!
+  where: StoreWhereInput
+}
+
+input StoreUpdateWithoutPurchaseRequisitionInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  location: NullableStringFieldUpdateOperationsInput
+  isMain: BoolFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  manager: UserUpdateOneRequiredWithoutStoreNestedInput
+  stocks: StockUpdateManyWithoutStoreNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutStoreNestedInput
+  transfersOut: StockTransferUpdateManyWithoutFromStoreNestedInput
+  transfersIn: StockTransferUpdateManyWithoutToStoreNestedInput
+  customerSales: ConsumerSaleUpdateManyWithoutStoreNestedInput
+  salesReturns: SalesReturnUpdateManyWithoutStoreNestedInput
+  resellerSales: ResellerSaleUpdateManyWithoutStoreNestedInput
+  movements: StockMovementUpdateManyWithoutStoreNestedInput
+  Customer: CustomerUpdateManyWithoutPreferredStoreNestedInput
+  CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
+  Quotation: QuotationUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
+}
+
+input PurchaseOrderUpdateManyWithoutStoreNestedInput {
+  create: [PurchaseOrderCreateWithoutStoreInput!]
+  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutStoreInput!]
+  upsert: [PurchaseOrderUpsertWithWhereUniqueWithoutStoreInput!]
+  createMany: PurchaseOrderCreateManyStoreInputEnvelope
+  set: [PurchaseOrderWhereUniqueInput!]
+  disconnect: [PurchaseOrderWhereUniqueInput!]
+  delete: [PurchaseOrderWhereUniqueInput!]
+  connect: [PurchaseOrderWhereUniqueInput!]
+  update: [PurchaseOrderUpdateWithWhereUniqueWithoutStoreInput!]
+  updateMany: [PurchaseOrderUpdateManyWithWhereWithoutStoreInput!]
+  deleteMany: [PurchaseOrderScalarWhereInput!]
+}
+
+input PurchaseOrderUpsertWithWhereUniqueWithoutStoreInput {
+  where: PurchaseOrderWhereUniqueInput!
+  update: PurchaseOrderUpdateWithoutStoreInput!
+  create: PurchaseOrderCreateWithoutStoreInput!
+}
+
+input PurchaseOrderUpdateWithoutStoreInput {
+  id: StringFieldUpdateOperationsInput
+  invoiceNumber: StringFieldUpdateOperationsInput
+  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
+  phase: EnumPurchasePhaseFieldUpdateOperationsInput
+  dueDate: DateTimeFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
+  items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
+  receipts: StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput
+  payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
+}
+
+input StockReceiptBatchUpdateManyWithoutPurchaseOrderNestedInput {
+  create: [StockReceiptBatchCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [StockReceiptBatchCreateOrConnectWithoutPurchaseOrderInput!]
+  upsert: [StockReceiptBatchUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
+  set: [StockReceiptBatchWhereUniqueInput!]
+  disconnect: [StockReceiptBatchWhereUniqueInput!]
+  delete: [StockReceiptBatchWhereUniqueInput!]
+  connect: [StockReceiptBatchWhereUniqueInput!]
+  update: [StockReceiptBatchUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
+  updateMany: [StockReceiptBatchUpdateManyWithWhereWithoutPurchaseOrderInput!]
+  deleteMany: [StockReceiptBatchScalarWhereInput!]
+}
+
+input StockReceiptBatchUpsertWithWhereUniqueWithoutPurchaseOrderInput {
+  where: StockReceiptBatchWhereUniqueInput!
+  update: StockReceiptBatchUpdateWithoutPurchaseOrderInput!
+  create: StockReceiptBatchCreateWithoutPurchaseOrderInput!
+}
+
+input StockReceiptBatchUpdateWithoutPurchaseOrderInput {
+  id: StringFieldUpdateOperationsInput
+  purchaseOrderId: StringFieldUpdateOperationsInput
+  waybillUrl: NullableStringFieldUpdateOperationsInput
+  receivedAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneRequiredWithoutReceiptsNestedInput
+  receivedBy: UserUpdateOneRequiredWithoutStockReceiptBatchReceivedBysNestedInput
+  confirmedBy: UserUpdateOneRequiredWithoutStockReceiptBatchConfirmedBysNestedInput
+  items: StockReceiptBatchItemUpdateManyWithoutBatchNestedInput
+  purchaseReturns: PurchaseReturnItemUpdateManyWithoutBatchNestedInput
+}
+
+input PurchaseReturnItemUpdateManyWithoutBatchNestedInput {
+  create: [PurchaseReturnItemCreateWithoutBatchInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutBatchInput!]
+  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutBatchInput!]
+  createMany: PurchaseReturnItemCreateManyBatchInputEnvelope
+  set: [PurchaseReturnItemWhereUniqueInput!]
+  disconnect: [PurchaseReturnItemWhereUniqueInput!]
+  delete: [PurchaseReturnItemWhereUniqueInput!]
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutBatchInput!]
+  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutBatchInput!]
+  deleteMany: [PurchaseReturnItemScalarWhereInput!]
+}
+
+input PurchaseReturnItemUpsertWithWhereUniqueWithoutBatchInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  update: PurchaseReturnItemUpdateWithoutBatchInput!
+  create: PurchaseReturnItemCreateWithoutBatchInput!
+}
+
+input PurchaseReturnItemUpdateWithoutBatchInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  return: PurchaseReturnUpdateOneRequiredWithoutItemsNestedInput
+  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput
+}
+
+input ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput {
+  create: ProductVariantCreateWithoutPurchaseReturnItemsInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutPurchaseReturnItemsInput
+  upsert: ProductVariantUpsertWithoutPurchaseReturnItemsInput
+  connect: ProductVariantWhereUniqueInput
+  update: ProductVariantUpdateToOneWithWhereWithoutPurchaseReturnItemsInput
+}
+
+input ProductVariantUpsertWithoutPurchaseReturnItemsInput {
+  update: ProductVariantUpdateWithoutPurchaseReturnItemsInput!
+  create: ProductVariantCreateWithoutPurchaseReturnItemsInput!
+  where: ProductVariantWhereInput
+}
+
+input ProductVariantUpdateWithoutPurchaseReturnItemsInput {
+  id: StringFieldUpdateOperationsInput
+  size: StringFieldUpdateOperationsInput
+  concentration: StringFieldUpdateOperationsInput
+  packaging: StringFieldUpdateOperationsInput
+  barcode: NullableStringFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
+  resellerPrice: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
+  stockItems: StockUpdateManyWithoutProductVariantNestedInput
+  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
+  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
+  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
+  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
+  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
+  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
+  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
+  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
+  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
+  SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
+  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
+}
+
+input PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput {
+  create: [PurchaseRequisitionItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [PurchaseRequisitionItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: PurchaseRequisitionItemCreateManyProductVariantInputEnvelope
+  set: [PurchaseRequisitionItemWhereUniqueInput!]
+  disconnect: [PurchaseRequisitionItemWhereUniqueInput!]
+  delete: [PurchaseRequisitionItemWhereUniqueInput!]
+  connect: [PurchaseRequisitionItemWhereUniqueInput!]
+  update: [PurchaseRequisitionItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [PurchaseRequisitionItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [PurchaseRequisitionItemScalarWhereInput!]
+}
+
+input PurchaseRequisitionItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseRequisitionItemWhereUniqueInput!
+  update: PurchaseRequisitionItemUpdateWithoutProductVariantInput!
+  create: PurchaseRequisitionItemCreateWithoutProductVariantInput!
+}
+
+input PurchaseRequisitionItemUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  requestedQty: IntFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  requisition: PurchaseRequisitionUpdateOneRequiredWithoutItemsNestedInput
+}
+
+input PurchaseRequisitionUpdateOneRequiredWithoutItemsNestedInput {
+  create: PurchaseRequisitionCreateWithoutItemsInput
+  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutItemsInput
+  upsert: PurchaseRequisitionUpsertWithoutItemsInput
+  connect: PurchaseRequisitionWhereUniqueInput
+  update: PurchaseRequisitionUpdateToOneWithWhereWithoutItemsInput
+}
+
+input PurchaseRequisitionUpsertWithoutItemsInput {
+  update: PurchaseRequisitionUpdateWithoutItemsInput!
+  create: PurchaseRequisitionCreateWithoutItemsInput!
+  where: PurchaseRequisitionWhereInput
+}
+
+input PurchaseRequisitionUpdateWithoutItemsInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
+  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
+  quotes: SupplierQuoteUpdateManyWithoutRequisitionNestedInput
+}
+
+input SupplierQuoteUpdateManyWithoutRequisitionNestedInput {
+  create: [SupplierQuoteCreateWithoutRequisitionInput!]
+  connectOrCreate: [SupplierQuoteCreateOrConnectWithoutRequisitionInput!]
+  upsert: [SupplierQuoteUpsertWithWhereUniqueWithoutRequisitionInput!]
+  createMany: SupplierQuoteCreateManyRequisitionInputEnvelope
+  set: [SupplierQuoteWhereUniqueInput!]
+  disconnect: [SupplierQuoteWhereUniqueInput!]
+  delete: [SupplierQuoteWhereUniqueInput!]
+  connect: [SupplierQuoteWhereUniqueInput!]
+  update: [SupplierQuoteUpdateWithWhereUniqueWithoutRequisitionInput!]
+  updateMany: [SupplierQuoteUpdateManyWithWhereWithoutRequisitionInput!]
+  deleteMany: [SupplierQuoteScalarWhereInput!]
+}
+
+input SupplierQuoteUpsertWithWhereUniqueWithoutRequisitionInput {
+  where: SupplierQuoteWhereUniqueInput!
+  update: SupplierQuoteUpdateWithoutRequisitionInput!
+  create: SupplierQuoteCreateWithoutRequisitionInput!
+}
+
+input SupplierQuoteUpdateWithoutRequisitionInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumSupplierQuoteStatusFieldUpdateOperationsInput
+  validUntil: NullableDateTimeFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutQuotesNestedInput
+  items: SupplierQuoteItemUpdateManyWithoutQuoteNestedInput
+}
+
+input EnumSupplierQuoteStatusFieldUpdateOperationsInput {
+  set: SupplierQuoteStatus
+}
+
+input SupplierUpdateOneRequiredWithoutQuotesNestedInput {
+  create: SupplierCreateWithoutQuotesInput
+  connectOrCreate: SupplierCreateOrConnectWithoutQuotesInput
+  upsert: SupplierUpsertWithoutQuotesInput
+  connect: SupplierWhereUniqueInput
+  update: SupplierUpdateToOneWithWhereWithoutQuotesInput
+}
+
+input SupplierUpsertWithoutQuotesInput {
+  update: SupplierUpdateWithoutQuotesInput!
+  create: SupplierCreateWithoutQuotesInput!
+  where: SupplierWhereInput
+}
+
+input SupplierUpdateWithoutQuotesInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  contactInfo: JSON
+  isFrequent: BoolFieldUpdateOperationsInput
+  creditLimit: FloatFieldUpdateOperationsInput
+  currentBalance: FloatFieldUpdateOperationsInput
+  paymentTerms: NullableStringFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutSupplierNestedInput
+  payments: SupplierPaymentUpdateManyWithoutSupplierNestedInput
+  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
+  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
+  user: UserUpdateOneWithoutSupplierNestedInput
+}
+
+input PurchaseReturnUpdateManyWithoutSupplierNestedInput {
+  create: [PurchaseReturnCreateWithoutSupplierInput!]
+  connectOrCreate: [PurchaseReturnCreateOrConnectWithoutSupplierInput!]
+  upsert: [PurchaseReturnUpsertWithWhereUniqueWithoutSupplierInput!]
+  createMany: PurchaseReturnCreateManySupplierInputEnvelope
+  set: [PurchaseReturnWhereUniqueInput!]
+  disconnect: [PurchaseReturnWhereUniqueInput!]
+  delete: [PurchaseReturnWhereUniqueInput!]
+  connect: [PurchaseReturnWhereUniqueInput!]
+  update: [PurchaseReturnUpdateWithWhereUniqueWithoutSupplierInput!]
+  updateMany: [PurchaseReturnUpdateManyWithWhereWithoutSupplierInput!]
+  deleteMany: [PurchaseReturnScalarWhereInput!]
+}
+
+input PurchaseReturnUpsertWithWhereUniqueWithoutSupplierInput {
+  where: PurchaseReturnWhereUniqueInput!
+  update: PurchaseReturnUpdateWithoutSupplierInput!
+  create: PurchaseReturnCreateWithoutSupplierInput!
+}
+
+input PurchaseReturnUpdateWithoutSupplierInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumReturnStatusFieldUpdateOperationsInput
+  reason: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  initiatedBy: UserUpdateOneRequiredWithoutPurchaseReturnInitiatorsNestedInput
+  approvedBy: UserUpdateOneRequiredWithoutPurchaseReturnApproversNestedInput
+  items: PurchaseReturnItemUpdateManyWithoutReturnNestedInput
+}
+
+input PurchaseReturnItemUpdateManyWithoutReturnNestedInput {
+  create: [PurchaseReturnItemCreateWithoutReturnInput!]
+  connectOrCreate: [PurchaseReturnItemCreateOrConnectWithoutReturnInput!]
+  upsert: [PurchaseReturnItemUpsertWithWhereUniqueWithoutReturnInput!]
+  createMany: PurchaseReturnItemCreateManyReturnInputEnvelope
+  set: [PurchaseReturnItemWhereUniqueInput!]
+  disconnect: [PurchaseReturnItemWhereUniqueInput!]
+  delete: [PurchaseReturnItemWhereUniqueInput!]
+  connect: [PurchaseReturnItemWhereUniqueInput!]
+  update: [PurchaseReturnItemUpdateWithWhereUniqueWithoutReturnInput!]
+  updateMany: [PurchaseReturnItemUpdateManyWithWhereWithoutReturnInput!]
+  deleteMany: [PurchaseReturnItemScalarWhereInput!]
+}
+
+input PurchaseReturnItemUpsertWithWhereUniqueWithoutReturnInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  update: PurchaseReturnItemUpdateWithoutReturnInput!
+  create: PurchaseReturnItemCreateWithoutReturnInput!
+}
+
+input PurchaseReturnItemUpdateWithoutReturnInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  productVariant: ProductVariantUpdateOneRequiredWithoutPurchaseReturnItemsNestedInput
+  batch: StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput
+}
+
+input StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput {
+  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput
+  connectOrCreate: StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput
+  upsert: StockReceiptBatchUpsertWithoutPurchaseReturnsInput
+  connect: StockReceiptBatchWhereUniqueInput
+  update: StockReceiptBatchUpdateToOneWithWhereWithoutPurchaseReturnsInput
+}
+
+input StockReceiptBatchUpsertWithoutPurchaseReturnsInput {
+  update: StockReceiptBatchUpdateWithoutPurchaseReturnsInput!
+  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput!
+  where: StockReceiptBatchWhereInput
+}
+
+input StockReceiptBatchUpdateWithoutPurchaseReturnsInput {
+  id: StringFieldUpdateOperationsInput
+  purchaseOrderId: StringFieldUpdateOperationsInput
+  waybillUrl: NullableStringFieldUpdateOperationsInput
+  receivedAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneRequiredWithoutReceiptsNestedInput
+  receivedBy: UserUpdateOneRequiredWithoutStockReceiptBatchReceivedBysNestedInput
+  confirmedBy: UserUpdateOneRequiredWithoutStockReceiptBatchConfirmedBysNestedInput
+  items: StockReceiptBatchItemUpdateManyWithoutBatchNestedInput
+  PurchaseOrder: PurchaseOrderUpdateManyWithoutReceiptsNestedInput
+}
+
+input PurchaseOrderUpdateManyWithoutReceiptsNestedInput {
+  create: [PurchaseOrderCreateWithoutReceiptsInput!]
+  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutReceiptsInput!]
+  upsert: [PurchaseOrderUpsertWithWhereUniqueWithoutReceiptsInput!]
+  set: [PurchaseOrderWhereUniqueInput!]
+  disconnect: [PurchaseOrderWhereUniqueInput!]
+  delete: [PurchaseOrderWhereUniqueInput!]
+  connect: [PurchaseOrderWhereUniqueInput!]
+  update: [PurchaseOrderUpdateWithWhereUniqueWithoutReceiptsInput!]
+  updateMany: [PurchaseOrderUpdateManyWithWhereWithoutReceiptsInput!]
+  deleteMany: [PurchaseOrderScalarWhereInput!]
+}
+
+input PurchaseOrderUpsertWithWhereUniqueWithoutReceiptsInput {
+  where: PurchaseOrderWhereUniqueInput!
+  update: PurchaseOrderUpdateWithoutReceiptsInput!
+  create: PurchaseOrderCreateWithoutReceiptsInput!
+}
+
+input PurchaseOrderUpdateWithoutReceiptsInput {
+  id: StringFieldUpdateOperationsInput
+  invoiceNumber: StringFieldUpdateOperationsInput
+  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
+  phase: EnumPurchasePhaseFieldUpdateOperationsInput
+  dueDate: DateTimeFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
+  store: StoreUpdateOneWithoutPurchaseOrdersNestedInput
+  items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
+  payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
+}
+
+input SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput {
+  create: [SupplierPaymentCreateWithoutPurchaseOrderInput!]
+  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput!]
+  upsert: [SupplierPaymentUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
+  createMany: SupplierPaymentCreateManyPurchaseOrderInputEnvelope
+  set: [SupplierPaymentWhereUniqueInput!]
+  disconnect: [SupplierPaymentWhereUniqueInput!]
+  delete: [SupplierPaymentWhereUniqueInput!]
+  connect: [SupplierPaymentWhereUniqueInput!]
+  update: [SupplierPaymentUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
+  updateMany: [SupplierPaymentUpdateManyWithWhereWithoutPurchaseOrderInput!]
+  deleteMany: [SupplierPaymentScalarWhereInput!]
+}
+
+input SupplierPaymentUpsertWithWhereUniqueWithoutPurchaseOrderInput {
+  where: SupplierPaymentWhereUniqueInput!
+  update: SupplierPaymentUpdateWithoutPurchaseOrderInput!
+  create: SupplierPaymentCreateWithoutPurchaseOrderInput!
+}
+
+input SupplierPaymentUpdateWithoutPurchaseOrderInput {
+  id: StringFieldUpdateOperationsInput
+  amount: FloatFieldUpdateOperationsInput
+  paymentDate: DateTimeFieldUpdateOperationsInput
+  method: StringFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  supplier: SupplierUpdateOneRequiredWithoutPaymentsNestedInput
+}
+
+input SupplierUpdateOneRequiredWithoutPaymentsNestedInput {
+  create: SupplierCreateWithoutPaymentsInput
+  connectOrCreate: SupplierCreateOrConnectWithoutPaymentsInput
+  upsert: SupplierUpsertWithoutPaymentsInput
+  connect: SupplierWhereUniqueInput
+  update: SupplierUpdateToOneWithWhereWithoutPaymentsInput
+}
+
+input SupplierUpsertWithoutPaymentsInput {
+  update: SupplierUpdateWithoutPaymentsInput!
+  create: SupplierCreateWithoutPaymentsInput!
+  where: SupplierWhereInput
+}
+
+input SupplierUpdateWithoutPaymentsInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  contactInfo: JSON
+  isFrequent: BoolFieldUpdateOperationsInput
+  creditLimit: FloatFieldUpdateOperationsInput
+  currentBalance: FloatFieldUpdateOperationsInput
+  paymentTerms: NullableStringFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutSupplierNestedInput
+  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
+  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
+  quotes: SupplierQuoteUpdateManyWithoutSupplierNestedInput
+  user: UserUpdateOneWithoutSupplierNestedInput
+}
+
+input SupplierCatalogUpdateManyWithoutSupplierNestedInput {
+  create: [SupplierCatalogCreateWithoutSupplierInput!]
+  connectOrCreate: [SupplierCatalogCreateOrConnectWithoutSupplierInput!]
+  upsert: [SupplierCatalogUpsertWithWhereUniqueWithoutSupplierInput!]
+  createMany: SupplierCatalogCreateManySupplierInputEnvelope
+  set: [SupplierCatalogWhereUniqueInput!]
+  disconnect: [SupplierCatalogWhereUniqueInput!]
+  delete: [SupplierCatalogWhereUniqueInput!]
+  connect: [SupplierCatalogWhereUniqueInput!]
+  update: [SupplierCatalogUpdateWithWhereUniqueWithoutSupplierInput!]
+  updateMany: [SupplierCatalogUpdateManyWithWhereWithoutSupplierInput!]
+  deleteMany: [SupplierCatalogScalarWhereInput!]
+}
+
+input SupplierCatalogUpsertWithWhereUniqueWithoutSupplierInput {
+  where: SupplierCatalogWhereUniqueInput!
+  update: SupplierCatalogUpdateWithoutSupplierInput!
+  create: SupplierCatalogCreateWithoutSupplierInput!
+}
+
+input SupplierCatalogUpdateWithoutSupplierInput {
+  id: StringFieldUpdateOperationsInput
+  defaultCost: FloatFieldUpdateOperationsInput
+  leadTimeDays: NullableIntFieldUpdateOperationsInput
+  isPreferred: BoolFieldUpdateOperationsInput
+  productVariant: ProductVariantUpdateOneRequiredWithoutSupplierCatalogNestedInput
+}
+
+input ProductVariantUpdateOneRequiredWithoutSupplierCatalogNestedInput {
+  create: ProductVariantCreateWithoutSupplierCatalogInput
+  connectOrCreate: ProductVariantCreateOrConnectWithoutSupplierCatalogInput
+  upsert: ProductVariantUpsertWithoutSupplierCatalogInput
+  connect: ProductVariantWhereUniqueInput
+  update: ProductVariantUpdateToOneWithWhereWithoutSupplierCatalogInput
+}
+
+input ProductVariantUpsertWithoutSupplierCatalogInput {
+  update: ProductVariantUpdateWithoutSupplierCatalogInput!
+  create: ProductVariantCreateWithoutSupplierCatalogInput!
+  where: ProductVariantWhereInput
+}
+
+input ProductVariantUpdateWithoutSupplierCatalogInput {
+  id: StringFieldUpdateOperationsInput
+  size: StringFieldUpdateOperationsInput
+  concentration: StringFieldUpdateOperationsInput
+  packaging: StringFieldUpdateOperationsInput
+  barcode: NullableStringFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
+  resellerPrice: FloatFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
+  stockItems: StockUpdateManyWithoutProductVariantNestedInput
+  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
+  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
+  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
+  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
+  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
+  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
+  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
+  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
+  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
+  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
+  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
+  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
+}
+
+input SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput {
+  create: [SupplierQuoteItemCreateWithoutProductVariantInput!]
+  connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutProductVariantInput!]
+  upsert: [SupplierQuoteItemUpsertWithWhereUniqueWithoutProductVariantInput!]
+  createMany: SupplierQuoteItemCreateManyProductVariantInputEnvelope
+  set: [SupplierQuoteItemWhereUniqueInput!]
+  disconnect: [SupplierQuoteItemWhereUniqueInput!]
+  delete: [SupplierQuoteItemWhereUniqueInput!]
+  connect: [SupplierQuoteItemWhereUniqueInput!]
+  update: [SupplierQuoteItemUpdateWithWhereUniqueWithoutProductVariantInput!]
+  updateMany: [SupplierQuoteItemUpdateManyWithWhereWithoutProductVariantInput!]
+  deleteMany: [SupplierQuoteItemScalarWhereInput!]
+}
+
+input SupplierQuoteItemUpsertWithWhereUniqueWithoutProductVariantInput {
+  where: SupplierQuoteItemWhereUniqueInput!
+  update: SupplierQuoteItemUpdateWithoutProductVariantInput!
+  create: SupplierQuoteItemCreateWithoutProductVariantInput!
+}
+
+input SupplierQuoteItemUpdateWithoutProductVariantInput {
+  id: StringFieldUpdateOperationsInput
+  unitCost: FloatFieldUpdateOperationsInput
+  minQty: NullableIntFieldUpdateOperationsInput
+  leadTimeDays: NullableIntFieldUpdateOperationsInput
+  quote: SupplierQuoteUpdateOneRequiredWithoutItemsNestedInput
+}
+
+input SupplierQuoteUpdateOneRequiredWithoutItemsNestedInput {
+  create: SupplierQuoteCreateWithoutItemsInput
+  connectOrCreate: SupplierQuoteCreateOrConnectWithoutItemsInput
+  upsert: SupplierQuoteUpsertWithoutItemsInput
+  connect: SupplierQuoteWhereUniqueInput
+  update: SupplierQuoteUpdateToOneWithWhereWithoutItemsInput
+}
+
+input SupplierQuoteUpsertWithoutItemsInput {
+  update: SupplierQuoteUpdateWithoutItemsInput!
+  create: SupplierQuoteCreateWithoutItemsInput!
+  where: SupplierQuoteWhereInput
+}
+
+input SupplierQuoteUpdateWithoutItemsInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumSupplierQuoteStatusFieldUpdateOperationsInput
+  validUntil: NullableDateTimeFieldUpdateOperationsInput
+  notes: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  requisition: PurchaseRequisitionUpdateOneRequiredWithoutQuotesNestedInput
+  supplier: SupplierUpdateOneRequiredWithoutQuotesNestedInput
+}
+
+input PurchaseRequisitionUpdateOneRequiredWithoutQuotesNestedInput {
+  create: PurchaseRequisitionCreateWithoutQuotesInput
+  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutQuotesInput
+  upsert: PurchaseRequisitionUpsertWithoutQuotesInput
+  connect: PurchaseRequisitionWhereUniqueInput
+  update: PurchaseRequisitionUpdateToOneWithWhereWithoutQuotesInput
+}
+
+input PurchaseRequisitionUpsertWithoutQuotesInput {
+  update: PurchaseRequisitionUpdateWithoutQuotesInput!
+  create: PurchaseRequisitionCreateWithoutQuotesInput!
+  where: PurchaseRequisitionWhereInput
+}
+
+input PurchaseRequisitionUpdateWithoutQuotesInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+  store: StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
+  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
+  items: PurchaseRequisitionItemUpdateManyWithoutRequisitionNestedInput
+}
+
 input PurchaseRequisitionItemUpdateManyWithoutRequisitionNestedInput {
   create: [PurchaseRequisitionItemCreateWithoutRequisitionInput!]
   connectOrCreate: [PurchaseRequisitionItemCreateOrConnectWithoutRequisitionInput!]
@@ -19455,6 +20042,7 @@ input ProductVariantUpdateWithoutPurchaseRequisitionItemInput {
   StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input SupplierCatalogUpdateManyWithoutProductVariantNestedInput {
@@ -19548,39 +20136,6 @@ input SupplierQuoteUpdateWithoutSupplierInput {
   items: SupplierQuoteItemUpdateManyWithoutQuoteNestedInput
 }
 
-input EnumSupplierQuoteStatusFieldUpdateOperationsInput {
-  set: SupplierQuoteStatus
-}
-
-input PurchaseRequisitionUpdateOneRequiredWithoutQuotesNestedInput {
-  create: PurchaseRequisitionCreateWithoutQuotesInput
-  connectOrCreate: PurchaseRequisitionCreateOrConnectWithoutQuotesInput
-  upsert: PurchaseRequisitionUpsertWithoutQuotesInput
-  connect: PurchaseRequisitionWhereUniqueInput
-  update: PurchaseRequisitionUpdateToOneWithWhereWithoutQuotesInput
-}
-
-input PurchaseRequisitionUpsertWithoutQuotesInput {
-  update: PurchaseRequisitionUpdateWithoutQuotesInput!
-  create: PurchaseRequisitionCreateWithoutQuotesInput!
-  where: PurchaseRequisitionWhereInput
-}
-
-input PurchaseRequisitionUpdateWithoutQuotesInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  store: StoreUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
-  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
-  items: PurchaseRequisitionItemUpdateManyWithoutRequisitionNestedInput
-}
-
-input PurchaseRequisitionUpdateToOneWithWhereWithoutQuotesInput {
-  where: PurchaseRequisitionWhereInput
-  data: PurchaseRequisitionUpdateWithoutQuotesInput!
-}
-
 input SupplierQuoteItemUpdateManyWithoutQuoteNestedInput {
   create: [SupplierQuoteItemCreateWithoutQuoteInput!]
   connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutQuoteInput!]
@@ -19647,6 +20202,59 @@ input ProductVariantUpdateWithoutSupplierQuoteItemInput {
   StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
+}
+
+input ProductVariantTierPriceUpdateManyWithoutVariantNestedInput {
+  create: [ProductVariantTierPriceCreateWithoutVariantInput!]
+  connectOrCreate: [ProductVariantTierPriceCreateOrConnectWithoutVariantInput!]
+  upsert: [ProductVariantTierPriceUpsertWithWhereUniqueWithoutVariantInput!]
+  createMany: ProductVariantTierPriceCreateManyVariantInputEnvelope
+  set: [ProductVariantTierPriceWhereUniqueInput!]
+  disconnect: [ProductVariantTierPriceWhereUniqueInput!]
+  delete: [ProductVariantTierPriceWhereUniqueInput!]
+  connect: [ProductVariantTierPriceWhereUniqueInput!]
+  update: [ProductVariantTierPriceUpdateWithWhereUniqueWithoutVariantInput!]
+  updateMany: [ProductVariantTierPriceUpdateManyWithWhereWithoutVariantInput!]
+  deleteMany: [ProductVariantTierPriceScalarWhereInput!]
+}
+
+input ProductVariantTierPriceUpsertWithWhereUniqueWithoutVariantInput {
+  where: ProductVariantTierPriceWhereUniqueInput!
+  update: ProductVariantTierPriceUpdateWithoutVariantInput!
+  create: ProductVariantTierPriceCreateWithoutVariantInput!
+}
+
+input ProductVariantTierPriceUpdateWithoutVariantInput {
+  id: StringFieldUpdateOperationsInput
+  tier: EnumUserTierFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
+}
+
+input ProductVariantTierPriceUpdateWithWhereUniqueWithoutVariantInput {
+  where: ProductVariantTierPriceWhereUniqueInput!
+  data: ProductVariantTierPriceUpdateWithoutVariantInput!
+}
+
+input ProductVariantTierPriceUpdateManyWithWhereWithoutVariantInput {
+  where: ProductVariantTierPriceScalarWhereInput!
+  data: ProductVariantTierPriceUpdateManyMutationInput!
+}
+
+input ProductVariantTierPriceScalarWhereInput {
+  AND: [ProductVariantTierPriceScalarWhereInput!]
+  OR: [ProductVariantTierPriceScalarWhereInput!]
+  NOT: [ProductVariantTierPriceScalarWhereInput!]
+  id: StringFilter
+  productVariantId: StringFilter
+  tier: EnumUserTierFilter
+  price: FloatFilter
+}
+
+input ProductVariantTierPriceUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  tier: EnumUserTierFieldUpdateOperationsInput
+  price: FloatFieldUpdateOperationsInput
 }
 
 input ProductVariantUpdateToOneWithWhereWithoutSupplierQuoteItemInput {
@@ -19817,194 +20425,6 @@ input SupplierCatalogUpdateManyMutationInput {
   isPreferred: BoolFieldUpdateOperationsInput
 }
 
-input SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput {
-  create: [SupplierQuoteItemCreateWithoutProductVariantInput!]
-  connectOrCreate: [SupplierQuoteItemCreateOrConnectWithoutProductVariantInput!]
-  upsert: [SupplierQuoteItemUpsertWithWhereUniqueWithoutProductVariantInput!]
-  createMany: SupplierQuoteItemCreateManyProductVariantInputEnvelope
-  set: [SupplierQuoteItemWhereUniqueInput!]
-  disconnect: [SupplierQuoteItemWhereUniqueInput!]
-  delete: [SupplierQuoteItemWhereUniqueInput!]
-  connect: [SupplierQuoteItemWhereUniqueInput!]
-  update: [SupplierQuoteItemUpdateWithWhereUniqueWithoutProductVariantInput!]
-  updateMany: [SupplierQuoteItemUpdateManyWithWhereWithoutProductVariantInput!]
-  deleteMany: [SupplierQuoteItemScalarWhereInput!]
-}
-
-input SupplierQuoteItemUpsertWithWhereUniqueWithoutProductVariantInput {
-  where: SupplierQuoteItemWhereUniqueInput!
-  update: SupplierQuoteItemUpdateWithoutProductVariantInput!
-  create: SupplierQuoteItemCreateWithoutProductVariantInput!
-}
-
-input SupplierQuoteItemUpdateWithoutProductVariantInput {
-  id: StringFieldUpdateOperationsInput
-  unitCost: FloatFieldUpdateOperationsInput
-  minQty: NullableIntFieldUpdateOperationsInput
-  leadTimeDays: NullableIntFieldUpdateOperationsInput
-  quote: SupplierQuoteUpdateOneRequiredWithoutItemsNestedInput
-}
-
-input SupplierQuoteUpdateOneRequiredWithoutItemsNestedInput {
-  create: SupplierQuoteCreateWithoutItemsInput
-  connectOrCreate: SupplierQuoteCreateOrConnectWithoutItemsInput
-  upsert: SupplierQuoteUpsertWithoutItemsInput
-  connect: SupplierQuoteWhereUniqueInput
-  update: SupplierQuoteUpdateToOneWithWhereWithoutItemsInput
-}
-
-input SupplierQuoteUpsertWithoutItemsInput {
-  update: SupplierQuoteUpdateWithoutItemsInput!
-  create: SupplierQuoteCreateWithoutItemsInput!
-  where: SupplierQuoteWhereInput
-}
-
-input SupplierQuoteUpdateWithoutItemsInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumSupplierQuoteStatusFieldUpdateOperationsInput
-  validUntil: NullableDateTimeFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  requisition: PurchaseRequisitionUpdateOneRequiredWithoutQuotesNestedInput
-  supplier: SupplierUpdateOneRequiredWithoutQuotesNestedInput
-}
-
-input SupplierUpdateOneRequiredWithoutQuotesNestedInput {
-  create: SupplierCreateWithoutQuotesInput
-  connectOrCreate: SupplierCreateOrConnectWithoutQuotesInput
-  upsert: SupplierUpsertWithoutQuotesInput
-  connect: SupplierWhereUniqueInput
-  update: SupplierUpdateToOneWithWhereWithoutQuotesInput
-}
-
-input SupplierUpsertWithoutQuotesInput {
-  update: SupplierUpdateWithoutQuotesInput!
-  create: SupplierCreateWithoutQuotesInput!
-  where: SupplierWhereInput
-}
-
-input SupplierUpdateWithoutQuotesInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-  contactInfo: JSON
-  isFrequent: BoolFieldUpdateOperationsInput
-  creditLimit: FloatFieldUpdateOperationsInput
-  currentBalance: FloatFieldUpdateOperationsInput
-  paymentTerms: NullableStringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  purchaseOrders: PurchaseOrderUpdateManyWithoutSupplierNestedInput
-  payments: SupplierPaymentUpdateManyWithoutSupplierNestedInput
-  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
-  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
-  user: UserUpdateOneWithoutSupplierNestedInput
-}
-
-input SupplierCatalogUpdateManyWithoutSupplierNestedInput {
-  create: [SupplierCatalogCreateWithoutSupplierInput!]
-  connectOrCreate: [SupplierCatalogCreateOrConnectWithoutSupplierInput!]
-  upsert: [SupplierCatalogUpsertWithWhereUniqueWithoutSupplierInput!]
-  createMany: SupplierCatalogCreateManySupplierInputEnvelope
-  set: [SupplierCatalogWhereUniqueInput!]
-  disconnect: [SupplierCatalogWhereUniqueInput!]
-  delete: [SupplierCatalogWhereUniqueInput!]
-  connect: [SupplierCatalogWhereUniqueInput!]
-  update: [SupplierCatalogUpdateWithWhereUniqueWithoutSupplierInput!]
-  updateMany: [SupplierCatalogUpdateManyWithWhereWithoutSupplierInput!]
-  deleteMany: [SupplierCatalogScalarWhereInput!]
-}
-
-input SupplierCatalogUpsertWithWhereUniqueWithoutSupplierInput {
-  where: SupplierCatalogWhereUniqueInput!
-  update: SupplierCatalogUpdateWithoutSupplierInput!
-  create: SupplierCatalogCreateWithoutSupplierInput!
-}
-
-input SupplierCatalogUpdateWithoutSupplierInput {
-  id: StringFieldUpdateOperationsInput
-  defaultCost: FloatFieldUpdateOperationsInput
-  leadTimeDays: NullableIntFieldUpdateOperationsInput
-  isPreferred: BoolFieldUpdateOperationsInput
-  productVariant: ProductVariantUpdateOneRequiredWithoutSupplierCatalogNestedInput
-}
-
-input ProductVariantUpdateOneRequiredWithoutSupplierCatalogNestedInput {
-  create: ProductVariantCreateWithoutSupplierCatalogInput
-  connectOrCreate: ProductVariantCreateOrConnectWithoutSupplierCatalogInput
-  upsert: ProductVariantUpsertWithoutSupplierCatalogInput
-  connect: ProductVariantWhereUniqueInput
-  update: ProductVariantUpdateToOneWithWhereWithoutSupplierCatalogInput
-}
-
-input ProductVariantUpsertWithoutSupplierCatalogInput {
-  update: ProductVariantUpdateWithoutSupplierCatalogInput!
-  create: ProductVariantCreateWithoutSupplierCatalogInput!
-  where: ProductVariantWhereInput
-}
-
-input ProductVariantUpdateWithoutSupplierCatalogInput {
-  id: StringFieldUpdateOperationsInput
-  size: StringFieldUpdateOperationsInput
-  concentration: StringFieldUpdateOperationsInput
-  packaging: StringFieldUpdateOperationsInput
-  barcode: NullableStringFieldUpdateOperationsInput
-  price: FloatFieldUpdateOperationsInput
-  resellerPrice: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  product: ProductUpdateOneRequiredWithoutVariantsNestedInput
-  stockItems: StockUpdateManyWithoutProductVariantNestedInput
-  receiptItems: StockReceiptBatchItemUpdateManyWithoutProductVariantNestedInput
-  quotationItems: QuotationItemUpdateManyWithoutProductVariantNestedInput
-  resellerItems: ResellerSaleItemUpdateManyWithoutProductVariantNestedInput
-  consumerItems: ConsumerSaleItemUpdateManyWithoutProductVariantNestedInput
-  returnItems: SalesReturnItemUpdateManyWithoutProductVariantNestedInput
-  purchaseReturnItems: PurchaseReturnItemUpdateManyWithoutProductVariantNestedInput
-  transferItems: StockTransferItemUpdateManyWithoutProductVariantNestedInput
-  stats: ProductSalesStatsUpdateOneWithoutProductVariantNestedInput
-  PurchaseOrderItem: PurchaseOrderItemUpdateManyWithoutProductVariantNestedInput
-  StockMovementItem: StockMovementItemUpdateManyWithoutProductVariantNestedInput
-  PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
-  SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
-}
-
-input ProductVariantUpdateToOneWithWhereWithoutSupplierCatalogInput {
-  where: ProductVariantWhereInput
-  data: ProductVariantUpdateWithoutSupplierCatalogInput!
-}
-
-input SupplierCatalogUpdateWithWhereUniqueWithoutSupplierInput {
-  where: SupplierCatalogWhereUniqueInput!
-  data: SupplierCatalogUpdateWithoutSupplierInput!
-}
-
-input SupplierCatalogUpdateManyWithWhereWithoutSupplierInput {
-  where: SupplierCatalogScalarWhereInput!
-  data: SupplierCatalogUpdateManyMutationInput!
-}
-
-input SupplierUpdateToOneWithWhereWithoutQuotesInput {
-  where: SupplierWhereInput
-  data: SupplierUpdateWithoutQuotesInput!
-}
-
-input SupplierQuoteUpdateToOneWithWhereWithoutItemsInput {
-  where: SupplierQuoteWhereInput
-  data: SupplierQuoteUpdateWithoutItemsInput!
-}
-
-input SupplierQuoteItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: SupplierQuoteItemWhereUniqueInput!
-  data: SupplierQuoteItemUpdateWithoutProductVariantInput!
-}
-
-input SupplierQuoteItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: SupplierQuoteItemScalarWhereInput!
-  data: SupplierQuoteItemUpdateManyMutationInput!
-}
-
 input ProductVariantUpdateToOneWithWhereWithoutPurchaseRequisitionItemInput {
   where: ProductVariantWhereInput
   data: ProductVariantUpdateWithoutPurchaseRequisitionItemInput!
@@ -20037,35 +20457,180 @@ input PurchaseRequisitionItemUpdateManyMutationInput {
   notes: NullableStringFieldUpdateOperationsInput
 }
 
-input SupplierQuoteUpdateManyWithoutRequisitionNestedInput {
-  create: [SupplierQuoteCreateWithoutRequisitionInput!]
-  connectOrCreate: [SupplierQuoteCreateOrConnectWithoutRequisitionInput!]
-  upsert: [SupplierQuoteUpsertWithWhereUniqueWithoutRequisitionInput!]
-  createMany: SupplierQuoteCreateManyRequisitionInputEnvelope
-  set: [SupplierQuoteWhereUniqueInput!]
-  disconnect: [SupplierQuoteWhereUniqueInput!]
-  delete: [SupplierQuoteWhereUniqueInput!]
-  connect: [SupplierQuoteWhereUniqueInput!]
-  update: [SupplierQuoteUpdateWithWhereUniqueWithoutRequisitionInput!]
-  updateMany: [SupplierQuoteUpdateManyWithWhereWithoutRequisitionInput!]
-  deleteMany: [SupplierQuoteScalarWhereInput!]
+input PurchaseRequisitionUpdateToOneWithWhereWithoutQuotesInput {
+  where: PurchaseRequisitionWhereInput
+  data: PurchaseRequisitionUpdateWithoutQuotesInput!
 }
 
-input SupplierQuoteUpsertWithWhereUniqueWithoutRequisitionInput {
-  where: SupplierQuoteWhereUniqueInput!
-  update: SupplierQuoteUpdateWithoutRequisitionInput!
-  create: SupplierQuoteCreateWithoutRequisitionInput!
+input SupplierQuoteUpdateToOneWithWhereWithoutItemsInput {
+  where: SupplierQuoteWhereInput
+  data: SupplierQuoteUpdateWithoutItemsInput!
 }
 
-input SupplierQuoteUpdateWithoutRequisitionInput {
+input SupplierQuoteItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: SupplierQuoteItemWhereUniqueInput!
+  data: SupplierQuoteItemUpdateWithoutProductVariantInput!
+}
+
+input SupplierQuoteItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: SupplierQuoteItemScalarWhereInput!
+  data: SupplierQuoteItemUpdateManyMutationInput!
+}
+
+input ProductVariantUpdateToOneWithWhereWithoutSupplierCatalogInput {
+  where: ProductVariantWhereInput
+  data: ProductVariantUpdateWithoutSupplierCatalogInput!
+}
+
+input SupplierCatalogUpdateWithWhereUniqueWithoutSupplierInput {
+  where: SupplierCatalogWhereUniqueInput!
+  data: SupplierCatalogUpdateWithoutSupplierInput!
+}
+
+input SupplierCatalogUpdateManyWithWhereWithoutSupplierInput {
+  where: SupplierCatalogScalarWhereInput!
+  data: SupplierCatalogUpdateManyMutationInput!
+}
+
+input SupplierUpdateToOneWithWhereWithoutPaymentsInput {
+  where: SupplierWhereInput
+  data: SupplierUpdateWithoutPaymentsInput!
+}
+
+input SupplierPaymentUpdateWithWhereUniqueWithoutPurchaseOrderInput {
+  where: SupplierPaymentWhereUniqueInput!
+  data: SupplierPaymentUpdateWithoutPurchaseOrderInput!
+}
+
+input SupplierPaymentUpdateManyWithWhereWithoutPurchaseOrderInput {
+  where: SupplierPaymentScalarWhereInput!
+  data: SupplierPaymentUpdateManyMutationInput!
+}
+
+input SupplierPaymentScalarWhereInput {
+  AND: [SupplierPaymentScalarWhereInput!]
+  OR: [SupplierPaymentScalarWhereInput!]
+  NOT: [SupplierPaymentScalarWhereInput!]
+  id: StringFilter
+  supplierId: StringFilter
+  purchaseOrderId: StringNullableFilter
+  amount: FloatFilter
+  paymentDate: DateTimeFilter
+  method: StringFilter
+  notes: StringNullableFilter
+}
+
+input SupplierPaymentUpdateManyMutationInput {
   id: StringFieldUpdateOperationsInput
-  status: EnumSupplierQuoteStatusFieldUpdateOperationsInput
-  validUntil: NullableDateTimeFieldUpdateOperationsInput
+  amount: FloatFieldUpdateOperationsInput
+  paymentDate: DateTimeFieldUpdateOperationsInput
+  method: StringFieldUpdateOperationsInput
   notes: NullableStringFieldUpdateOperationsInput
+}
+
+input PurchaseOrderUpdateWithWhereUniqueWithoutReceiptsInput {
+  where: PurchaseOrderWhereUniqueInput!
+  data: PurchaseOrderUpdateWithoutReceiptsInput!
+}
+
+input PurchaseOrderUpdateManyWithWhereWithoutReceiptsInput {
+  where: PurchaseOrderScalarWhereInput!
+  data: PurchaseOrderUpdateManyMutationInput!
+}
+
+input PurchaseOrderScalarWhereInput {
+  AND: [PurchaseOrderScalarWhereInput!]
+  OR: [PurchaseOrderScalarWhereInput!]
+  NOT: [PurchaseOrderScalarWhereInput!]
+  id: StringFilter
+  supplierId: StringFilter
+  storeId: StringNullableFilter
+  invoiceNumber: StringFilter
+  status: EnumPurchaseOrderStatusFilter
+  phase: EnumPurchasePhaseFilter
+  dueDate: DateTimeFilter
+  totalAmount: FloatFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input PurchaseOrderUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  invoiceNumber: StringFieldUpdateOperationsInput
+  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
+  phase: EnumPurchasePhaseFieldUpdateOperationsInput
+  dueDate: DateTimeFieldUpdateOperationsInput
+  totalAmount: FloatFieldUpdateOperationsInput
   createdAt: DateTimeFieldUpdateOperationsInput
   updatedAt: DateTimeFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutQuotesNestedInput
-  items: SupplierQuoteItemUpdateManyWithoutQuoteNestedInput
+}
+
+input StockReceiptBatchUpdateToOneWithWhereWithoutPurchaseReturnsInput {
+  where: StockReceiptBatchWhereInput
+  data: StockReceiptBatchUpdateWithoutPurchaseReturnsInput!
+}
+
+input PurchaseReturnItemUpdateWithWhereUniqueWithoutReturnInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  data: PurchaseReturnItemUpdateWithoutReturnInput!
+}
+
+input PurchaseReturnItemUpdateManyWithWhereWithoutReturnInput {
+  where: PurchaseReturnItemScalarWhereInput!
+  data: PurchaseReturnItemUpdateManyMutationInput!
+}
+
+input PurchaseReturnItemScalarWhereInput {
+  AND: [PurchaseReturnItemScalarWhereInput!]
+  OR: [PurchaseReturnItemScalarWhereInput!]
+  NOT: [PurchaseReturnItemScalarWhereInput!]
+  id: StringFilter
+  purchaseReturnId: StringFilter
+  productVariantId: StringFilter
+  batchId: StringFilter
+  quantity: IntFilter
+}
+
+input PurchaseReturnItemUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+}
+
+input PurchaseReturnUpdateWithWhereUniqueWithoutSupplierInput {
+  where: PurchaseReturnWhereUniqueInput!
+  data: PurchaseReturnUpdateWithoutSupplierInput!
+}
+
+input PurchaseReturnUpdateManyWithWhereWithoutSupplierInput {
+  where: PurchaseReturnScalarWhereInput!
+  data: PurchaseReturnUpdateManyMutationInput!
+}
+
+input PurchaseReturnScalarWhereInput {
+  AND: [PurchaseReturnScalarWhereInput!]
+  OR: [PurchaseReturnScalarWhereInput!]
+  NOT: [PurchaseReturnScalarWhereInput!]
+  id: StringFilter
+  supplierId: StringFilter
+  initiatedById: StringFilter
+  approvedById: StringFilter
+  status: EnumReturnStatusFilter
+  reason: StringNullableFilter
+  createdAt: DateTimeFilter
+  updatedAt: DateTimeFilter
+}
+
+input PurchaseReturnUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  status: EnumReturnStatusFieldUpdateOperationsInput
+  reason: NullableStringFieldUpdateOperationsInput
+  createdAt: DateTimeFieldUpdateOperationsInput
+  updatedAt: DateTimeFieldUpdateOperationsInput
+}
+
+input SupplierUpdateToOneWithWhereWithoutQuotesInput {
+  where: SupplierWhereInput
+  data: SupplierUpdateWithoutQuotesInput!
 }
 
 input SupplierQuoteUpdateWithWhereUniqueWithoutRequisitionInput {
@@ -20076,6 +20641,81 @@ input SupplierQuoteUpdateWithWhereUniqueWithoutRequisitionInput {
 input SupplierQuoteUpdateManyWithWhereWithoutRequisitionInput {
   where: SupplierQuoteScalarWhereInput!
   data: SupplierQuoteUpdateManyMutationInput!
+}
+
+input PurchaseRequisitionUpdateToOneWithWhereWithoutItemsInput {
+  where: PurchaseRequisitionWhereInput
+  data: PurchaseRequisitionUpdateWithoutItemsInput!
+}
+
+input PurchaseRequisitionItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseRequisitionItemWhereUniqueInput!
+  data: PurchaseRequisitionItemUpdateWithoutProductVariantInput!
+}
+
+input PurchaseRequisitionItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: PurchaseRequisitionItemScalarWhereInput!
+  data: PurchaseRequisitionItemUpdateManyMutationInput!
+}
+
+input ProductVariantUpdateToOneWithWhereWithoutPurchaseReturnItemsInput {
+  where: ProductVariantWhereInput
+  data: ProductVariantUpdateWithoutPurchaseReturnItemsInput!
+}
+
+input PurchaseReturnItemUpdateWithWhereUniqueWithoutBatchInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  data: PurchaseReturnItemUpdateWithoutBatchInput!
+}
+
+input PurchaseReturnItemUpdateManyWithWhereWithoutBatchInput {
+  where: PurchaseReturnItemScalarWhereInput!
+  data: PurchaseReturnItemUpdateManyMutationInput!
+}
+
+input StockReceiptBatchUpdateWithWhereUniqueWithoutPurchaseOrderInput {
+  where: StockReceiptBatchWhereUniqueInput!
+  data: StockReceiptBatchUpdateWithoutPurchaseOrderInput!
+}
+
+input StockReceiptBatchUpdateManyWithWhereWithoutPurchaseOrderInput {
+  where: StockReceiptBatchScalarWhereInput!
+  data: StockReceiptBatchUpdateManyMutationInput!
+}
+
+input StockReceiptBatchScalarWhereInput {
+  AND: [StockReceiptBatchScalarWhereInput!]
+  OR: [StockReceiptBatchScalarWhereInput!]
+  NOT: [StockReceiptBatchScalarWhereInput!]
+  id: StringFilter
+  purchaseOrderId: StringFilter
+  storeId: StringFilter
+  receivedById: StringFilter
+  confirmedById: StringFilter
+  waybillUrl: StringNullableFilter
+  receivedAt: DateTimeFilter
+}
+
+input StockReceiptBatchUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  purchaseOrderId: StringFieldUpdateOperationsInput
+  waybillUrl: NullableStringFieldUpdateOperationsInput
+  receivedAt: DateTimeFieldUpdateOperationsInput
+}
+
+input PurchaseOrderUpdateWithWhereUniqueWithoutStoreInput {
+  where: PurchaseOrderWhereUniqueInput!
+  data: PurchaseOrderUpdateWithoutStoreInput!
+}
+
+input PurchaseOrderUpdateManyWithWhereWithoutStoreInput {
+  where: PurchaseOrderScalarWhereInput!
+  data: PurchaseOrderUpdateManyMutationInput!
+}
+
+input StoreUpdateToOneWithWhereWithoutPurchaseRequisitionInput {
+  where: StoreWhereInput
+  data: StoreUpdateWithoutPurchaseRequisitionInput!
 }
 
 input PurchaseRequisitionUpdateWithWhereUniqueWithoutRequestedByInput {
@@ -20840,19 +21480,116 @@ input UserUpdateToOneWithWhereWithoutPurchaseRequisitionInput {
   data: UserUpdateWithoutPurchaseRequisitionInput!
 }
 
-input PurchaseRequisitionUpdateToOneWithWhereWithoutItemsInput {
-  where: PurchaseRequisitionWhereInput
-  data: PurchaseRequisitionUpdateWithoutItemsInput!
+input PurchaseRequisitionUpdateWithWhereUniqueWithoutStoreInput {
+  where: PurchaseRequisitionWhereUniqueInput!
+  data: PurchaseRequisitionUpdateWithoutStoreInput!
 }
 
-input PurchaseRequisitionItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseRequisitionItemWhereUniqueInput!
-  data: PurchaseRequisitionItemUpdateWithoutProductVariantInput!
+input PurchaseRequisitionUpdateManyWithWhereWithoutStoreInput {
+  where: PurchaseRequisitionScalarWhereInput!
+  data: PurchaseRequisitionUpdateManyMutationInput!
 }
 
-input PurchaseRequisitionItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: PurchaseRequisitionItemScalarWhereInput!
-  data: PurchaseRequisitionItemUpdateManyMutationInput!
+input StoreUpdateToOneWithWhereWithoutMovementsInput {
+  where: StoreWhereInput
+  data: StoreUpdateWithoutMovementsInput!
+}
+
+input StockMovementUpdateToOneWithWhereWithoutItemsInput {
+  where: StockMovementWhereInput
+  data: StockMovementUpdateWithoutItemsInput!
+}
+
+input StockMovementItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: StockMovementItemWhereUniqueInput!
+  data: StockMovementItemUpdateWithoutProductVariantInput!
+}
+
+input StockMovementItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: StockMovementItemScalarWhereInput!
+  data: StockMovementItemUpdateManyMutationInput!
+}
+
+input StockMovementItemScalarWhereInput {
+  AND: [StockMovementItemScalarWhereInput!]
+  OR: [StockMovementItemScalarWhereInput!]
+  NOT: [StockMovementItemScalarWhereInput!]
+  id: StringFilter
+  stockMovementId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+}
+
+input StockMovementItemUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+}
+
+input ProductVariantUpdateToOneWithWhereWithoutPurchaseOrderItemInput {
+  where: ProductVariantWhereInput
+  data: ProductVariantUpdateWithoutPurchaseOrderItemInput!
+}
+
+input PurchaseOrderItemUpdateWithWhereUniqueWithoutPurchaseOrderInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  data: PurchaseOrderItemUpdateWithoutPurchaseOrderInput!
+}
+
+input PurchaseOrderItemUpdateManyWithWhereWithoutPurchaseOrderInput {
+  where: PurchaseOrderItemScalarWhereInput!
+  data: PurchaseOrderItemUpdateManyMutationInput!
+}
+
+input PurchaseOrderItemScalarWhereInput {
+  AND: [PurchaseOrderItemScalarWhereInput!]
+  OR: [PurchaseOrderItemScalarWhereInput!]
+  NOT: [PurchaseOrderItemScalarWhereInput!]
+  id: StringFilter
+  purchaseOrderId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  unitCost: FloatFilter
+}
+
+input PurchaseOrderItemUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  unitCost: FloatFieldUpdateOperationsInput
+}
+
+input PurchaseOrderUpdateToOneWithWhereWithoutPaymentsInput {
+  where: PurchaseOrderWhereInput
+  data: PurchaseOrderUpdateWithoutPaymentsInput!
+}
+
+input SupplierPaymentUpdateWithWhereUniqueWithoutSupplierInput {
+  where: SupplierPaymentWhereUniqueInput!
+  data: SupplierPaymentUpdateWithoutSupplierInput!
+}
+
+input SupplierPaymentUpdateManyWithWhereWithoutSupplierInput {
+  where: SupplierPaymentScalarWhereInput!
+  data: SupplierPaymentUpdateManyMutationInput!
+}
+
+input SupplierUpdateToOneWithWhereWithoutPurchaseOrdersInput {
+  where: SupplierWhereInput
+  data: SupplierUpdateWithoutPurchaseOrdersInput!
+}
+
+input PurchaseOrderUpdateToOneWithWhereWithoutItemsInput {
+  where: PurchaseOrderWhereInput
+  data: PurchaseOrderUpdateWithoutItemsInput!
+}
+
+input PurchaseOrderItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseOrderItemWhereUniqueInput!
+  data: PurchaseOrderItemUpdateWithoutProductVariantInput!
+}
+
+input PurchaseOrderItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: PurchaseOrderItemScalarWhereInput!
+  data: PurchaseOrderItemUpdateManyMutationInput!
 }
 
 input ProductVariantUpdateToOneWithWhereWithoutReturnItemsInput {
@@ -20931,163 +21668,6 @@ input ResellerSaleUpdateToOneWithWhereWithoutQuotationInput {
   data: ResellerSaleUpdateWithoutQuotationInput!
 }
 
-input QuotationUpdateWithWhereUniqueWithoutStoreInput {
-  where: QuotationWhereUniqueInput!
-  data: QuotationUpdateWithoutStoreInput!
-}
-
-input QuotationUpdateManyWithWhereWithoutStoreInput {
-  where: QuotationScalarWhereInput!
-  data: QuotationUpdateManyMutationInput!
-}
-
-input PurchaseRequisitionUpdateManyWithoutStoreNestedInput {
-  create: [PurchaseRequisitionCreateWithoutStoreInput!]
-  connectOrCreate: [PurchaseRequisitionCreateOrConnectWithoutStoreInput!]
-  upsert: [PurchaseRequisitionUpsertWithWhereUniqueWithoutStoreInput!]
-  createMany: PurchaseRequisitionCreateManyStoreInputEnvelope
-  set: [PurchaseRequisitionWhereUniqueInput!]
-  disconnect: [PurchaseRequisitionWhereUniqueInput!]
-  delete: [PurchaseRequisitionWhereUniqueInput!]
-  connect: [PurchaseRequisitionWhereUniqueInput!]
-  update: [PurchaseRequisitionUpdateWithWhereUniqueWithoutStoreInput!]
-  updateMany: [PurchaseRequisitionUpdateManyWithWhereWithoutStoreInput!]
-  deleteMany: [PurchaseRequisitionScalarWhereInput!]
-}
-
-input PurchaseRequisitionUpsertWithWhereUniqueWithoutStoreInput {
-  where: PurchaseRequisitionWhereUniqueInput!
-  update: PurchaseRequisitionUpdateWithoutStoreInput!
-  create: PurchaseRequisitionCreateWithoutStoreInput!
-}
-
-input PurchaseRequisitionUpdateWithoutStoreInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumPurchaseRequisitionStatusFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  requestedBy: UserUpdateOneRequiredWithoutPurchaseRequisitionNestedInput
-  items: PurchaseRequisitionItemUpdateManyWithoutRequisitionNestedInput
-  quotes: SupplierQuoteUpdateManyWithoutRequisitionNestedInput
-}
-
-input PurchaseRequisitionUpdateWithWhereUniqueWithoutStoreInput {
-  where: PurchaseRequisitionWhereUniqueInput!
-  data: PurchaseRequisitionUpdateWithoutStoreInput!
-}
-
-input PurchaseRequisitionUpdateManyWithWhereWithoutStoreInput {
-  where: PurchaseRequisitionScalarWhereInput!
-  data: PurchaseRequisitionUpdateManyMutationInput!
-}
-
-input StoreUpdateToOneWithWhereWithoutSalesReturnsInput {
-  where: StoreWhereInput
-  data: StoreUpdateWithoutSalesReturnsInput!
-}
-
-input SalesReturnUpdateWithWhereUniqueWithoutConsumerSaleInput {
-  where: SalesReturnWhereUniqueInput!
-  data: SalesReturnUpdateWithoutConsumerSaleInput!
-}
-
-input SalesReturnUpdateManyWithWhereWithoutConsumerSaleInput {
-  where: SalesReturnScalarWhereInput!
-  data: SalesReturnUpdateManyMutationInput!
-}
-
-input ConsumerSaleUpdateWithWhereUniqueWithoutCustomerProfileInput {
-  where: ConsumerSaleWhereUniqueInput!
-  data: ConsumerSaleUpdateWithoutCustomerProfileInput!
-}
-
-input ConsumerSaleUpdateManyWithWhereWithoutCustomerProfileInput {
-  where: ConsumerSaleScalarWhereInput!
-  data: ConsumerSaleUpdateManyMutationInput!
-}
-
-input CustomerProfileUpdateToOneWithWhereWithoutReferralsInput {
-  where: CustomerProfileWhereInput
-  data: CustomerProfileUpdateWithoutReferralsInput!
-}
-
-input CustomerProfileUpdateWithWhereUniqueWithoutPreferredStoreInput {
-  where: CustomerProfileWhereUniqueInput!
-  data: CustomerProfileUpdateWithoutPreferredStoreInput!
-}
-
-input CustomerProfileUpdateManyWithWhereWithoutPreferredStoreInput {
-  where: CustomerProfileScalarWhereInput!
-  data: CustomerProfileUpdateManyMutationInput!
-}
-
-input StoreUpdateToOneWithWhereWithoutMovementsInput {
-  where: StoreWhereInput
-  data: StoreUpdateWithoutMovementsInput!
-}
-
-input StockMovementUpdateToOneWithWhereWithoutItemsInput {
-  where: StockMovementWhereInput
-  data: StockMovementUpdateWithoutItemsInput!
-}
-
-input StockMovementItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: StockMovementItemWhereUniqueInput!
-  data: StockMovementItemUpdateWithoutProductVariantInput!
-}
-
-input StockMovementItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: StockMovementItemScalarWhereInput!
-  data: StockMovementItemUpdateManyMutationInput!
-}
-
-input StockMovementItemScalarWhereInput {
-  AND: [StockMovementItemScalarWhereInput!]
-  OR: [StockMovementItemScalarWhereInput!]
-  NOT: [StockMovementItemScalarWhereInput!]
-  id: StringFilter
-  stockMovementId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-}
-
-input StockMovementItemUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-}
-
-input ProductVariantUpdateToOneWithWhereWithoutQuotationItemsInput {
-  where: ProductVariantWhereInput
-  data: ProductVariantUpdateWithoutQuotationItemsInput!
-}
-
-input QuotationItemUpdateWithWhereUniqueWithoutQuotationInput {
-  where: QuotationItemWhereUniqueInput!
-  data: QuotationItemUpdateWithoutQuotationInput!
-}
-
-input QuotationItemUpdateManyWithWhereWithoutQuotationInput {
-  where: QuotationItemScalarWhereInput!
-  data: QuotationItemUpdateManyMutationInput!
-}
-
-input QuotationItemScalarWhereInput {
-  AND: [QuotationItemScalarWhereInput!]
-  OR: [QuotationItemScalarWhereInput!]
-  NOT: [QuotationItemScalarWhereInput!]
-  id: StringFilter
-  quotationId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  unitPrice: FloatFilter
-}
-
-input QuotationItemUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  unitPrice: FloatFieldUpdateOperationsInput
-}
-
 input QuotationUpdateWithWhereUniqueWithoutBillerInput {
   where: QuotationWhereUniqueInput!
   data: QuotationUpdateWithoutBillerInput!
@@ -21132,9 +21712,56 @@ input ResellerTierHistoryUpdateManyMutationInput {
   changedAt: DateTimeFieldUpdateOperationsInput
 }
 
-input UserUpdateToOneWithWhereWithoutResellerQuotationInput {
+input UserUpdateToOneWithWhereWithoutPurchaseReturnApproversInput {
   where: UserWhereInput
-  data: UserUpdateWithoutResellerQuotationInput!
+  data: UserUpdateWithoutPurchaseReturnApproversInput!
+}
+
+input PurchaseReturnUpdateToOneWithWhereWithoutItemsInput {
+  where: PurchaseReturnWhereInput
+  data: PurchaseReturnUpdateWithoutItemsInput!
+}
+
+input PurchaseReturnItemUpdateWithWhereUniqueWithoutProductVariantInput {
+  where: PurchaseReturnItemWhereUniqueInput!
+  data: PurchaseReturnItemUpdateWithoutProductVariantInput!
+}
+
+input PurchaseReturnItemUpdateManyWithWhereWithoutProductVariantInput {
+  where: PurchaseReturnItemScalarWhereInput!
+  data: PurchaseReturnItemUpdateManyMutationInput!
+}
+
+input ProductVariantUpdateToOneWithWhereWithoutQuotationItemsInput {
+  where: ProductVariantWhereInput
+  data: ProductVariantUpdateWithoutQuotationItemsInput!
+}
+
+input QuotationItemUpdateWithWhereUniqueWithoutQuotationInput {
+  where: QuotationItemWhereUniqueInput!
+  data: QuotationItemUpdateWithoutQuotationInput!
+}
+
+input QuotationItemUpdateManyWithWhereWithoutQuotationInput {
+  where: QuotationItemScalarWhereInput!
+  data: QuotationItemUpdateManyMutationInput!
+}
+
+input QuotationItemScalarWhereInput {
+  AND: [QuotationItemScalarWhereInput!]
+  OR: [QuotationItemScalarWhereInput!]
+  NOT: [QuotationItemScalarWhereInput!]
+  id: StringFilter
+  quotationId: StringFilter
+  productVariantId: StringFilter
+  quantity: IntFilter
+  unitPrice: FloatFilter
+}
+
+input QuotationItemUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  quantity: IntFieldUpdateOperationsInput
+  unitPrice: FloatFieldUpdateOperationsInput
 }
 
 input QuotationUpdateToOneWithWhereWithoutSaleOrderInput {
@@ -21199,269 +21826,9 @@ input ResellerTierHistoryUpdateManyWithWhereWithoutUserInput {
   data: ResellerTierHistoryUpdateManyMutationInput!
 }
 
-input UserUpdateToOneWithWhereWithoutPurchaseReturnApproversInput {
+input UserUpdateToOneWithWhereWithoutPurchaseReturnInitiatorsInput {
   where: UserWhereInput
-  data: UserUpdateWithoutPurchaseReturnApproversInput!
-}
-
-input PurchaseReturnUpdateWithWhereUniqueWithoutSupplierInput {
-  where: PurchaseReturnWhereUniqueInput!
-  data: PurchaseReturnUpdateWithoutSupplierInput!
-}
-
-input PurchaseReturnUpdateManyWithWhereWithoutSupplierInput {
-  where: PurchaseReturnScalarWhereInput!
-  data: PurchaseReturnUpdateManyMutationInput!
-}
-
-input PurchaseReturnScalarWhereInput {
-  AND: [PurchaseReturnScalarWhereInput!]
-  OR: [PurchaseReturnScalarWhereInput!]
-  NOT: [PurchaseReturnScalarWhereInput!]
-  id: StringFilter
-  supplierId: StringFilter
-  initiatedById: StringFilter
-  approvedById: StringFilter
-  status: EnumReturnStatusFilter
-  reason: StringNullableFilter
-  createdAt: DateTimeFilter
-  updatedAt: DateTimeFilter
-}
-
-input PurchaseReturnUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  status: EnumReturnStatusFieldUpdateOperationsInput
-  reason: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-}
-
-input SupplierUpdateToOneWithWhereWithoutPurchaseOrdersInput {
-  where: SupplierWhereInput
-  data: SupplierUpdateWithoutPurchaseOrdersInput!
-}
-
-input SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput {
-  create: [SupplierPaymentCreateWithoutPurchaseOrderInput!]
-  connectOrCreate: [SupplierPaymentCreateOrConnectWithoutPurchaseOrderInput!]
-  upsert: [SupplierPaymentUpsertWithWhereUniqueWithoutPurchaseOrderInput!]
-  createMany: SupplierPaymentCreateManyPurchaseOrderInputEnvelope
-  set: [SupplierPaymentWhereUniqueInput!]
-  disconnect: [SupplierPaymentWhereUniqueInput!]
-  delete: [SupplierPaymentWhereUniqueInput!]
-  connect: [SupplierPaymentWhereUniqueInput!]
-  update: [SupplierPaymentUpdateWithWhereUniqueWithoutPurchaseOrderInput!]
-  updateMany: [SupplierPaymentUpdateManyWithWhereWithoutPurchaseOrderInput!]
-  deleteMany: [SupplierPaymentScalarWhereInput!]
-}
-
-input SupplierPaymentUpsertWithWhereUniqueWithoutPurchaseOrderInput {
-  where: SupplierPaymentWhereUniqueInput!
-  update: SupplierPaymentUpdateWithoutPurchaseOrderInput!
-  create: SupplierPaymentCreateWithoutPurchaseOrderInput!
-}
-
-input SupplierPaymentUpdateWithoutPurchaseOrderInput {
-  id: StringFieldUpdateOperationsInput
-  amount: FloatFieldUpdateOperationsInput
-  paymentDate: DateTimeFieldUpdateOperationsInput
-  method: StringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutPaymentsNestedInput
-}
-
-input SupplierUpdateOneRequiredWithoutPaymentsNestedInput {
-  create: SupplierCreateWithoutPaymentsInput
-  connectOrCreate: SupplierCreateOrConnectWithoutPaymentsInput
-  upsert: SupplierUpsertWithoutPaymentsInput
-  connect: SupplierWhereUniqueInput
-  update: SupplierUpdateToOneWithWhereWithoutPaymentsInput
-}
-
-input SupplierUpsertWithoutPaymentsInput {
-  update: SupplierUpdateWithoutPaymentsInput!
-  create: SupplierCreateWithoutPaymentsInput!
-  where: SupplierWhereInput
-}
-
-input SupplierUpdateWithoutPaymentsInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-  contactInfo: JSON
-  isFrequent: BoolFieldUpdateOperationsInput
-  creditLimit: FloatFieldUpdateOperationsInput
-  currentBalance: FloatFieldUpdateOperationsInput
-  paymentTerms: NullableStringFieldUpdateOperationsInput
-  notes: NullableStringFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  purchaseOrders: PurchaseOrderUpdateManyWithoutSupplierNestedInput
-  returns: PurchaseReturnUpdateManyWithoutSupplierNestedInput
-  catalogs: SupplierCatalogUpdateManyWithoutSupplierNestedInput
-  quotes: SupplierQuoteUpdateManyWithoutSupplierNestedInput
-  user: UserUpdateOneWithoutSupplierNestedInput
-}
-
-input SupplierUpdateToOneWithWhereWithoutPaymentsInput {
-  where: SupplierWhereInput
-  data: SupplierUpdateWithoutPaymentsInput!
-}
-
-input SupplierPaymentUpdateWithWhereUniqueWithoutPurchaseOrderInput {
-  where: SupplierPaymentWhereUniqueInput!
-  data: SupplierPaymentUpdateWithoutPurchaseOrderInput!
-}
-
-input SupplierPaymentUpdateManyWithWhereWithoutPurchaseOrderInput {
-  where: SupplierPaymentScalarWhereInput!
-  data: SupplierPaymentUpdateManyMutationInput!
-}
-
-input PurchaseOrderUpdateToOneWithWhereWithoutItemsInput {
-  where: PurchaseOrderWhereInput
-  data: PurchaseOrderUpdateWithoutItemsInput!
-}
-
-input PurchaseOrderItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  data: PurchaseOrderItemUpdateWithoutProductVariantInput!
-}
-
-input PurchaseOrderItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: PurchaseOrderItemScalarWhereInput!
-  data: PurchaseOrderItemUpdateManyMutationInput!
-}
-
-input PurchaseOrderItemScalarWhereInput {
-  AND: [PurchaseOrderItemScalarWhereInput!]
-  OR: [PurchaseOrderItemScalarWhereInput!]
-  NOT: [PurchaseOrderItemScalarWhereInput!]
-  id: StringFilter
-  purchaseOrderId: StringFilter
-  productVariantId: StringFilter
-  quantity: IntFilter
-  unitCost: FloatFilter
-}
-
-input PurchaseOrderItemUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  quantity: IntFieldUpdateOperationsInput
-  unitCost: FloatFieldUpdateOperationsInput
-}
-
-input ProductVariantUpdateToOneWithWhereWithoutPurchaseReturnItemsInput {
-  where: ProductVariantWhereInput
-  data: ProductVariantUpdateWithoutPurchaseReturnItemsInput!
-}
-
-input StockReceiptBatchUpdateOneRequiredWithoutPurchaseReturnsNestedInput {
-  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput
-  connectOrCreate: StockReceiptBatchCreateOrConnectWithoutPurchaseReturnsInput
-  upsert: StockReceiptBatchUpsertWithoutPurchaseReturnsInput
-  connect: StockReceiptBatchWhereUniqueInput
-  update: StockReceiptBatchUpdateToOneWithWhereWithoutPurchaseReturnsInput
-}
-
-input StockReceiptBatchUpsertWithoutPurchaseReturnsInput {
-  update: StockReceiptBatchUpdateWithoutPurchaseReturnsInput!
-  create: StockReceiptBatchCreateWithoutPurchaseReturnsInput!
-  where: StockReceiptBatchWhereInput
-}
-
-input StockReceiptBatchUpdateWithoutPurchaseReturnsInput {
-  id: StringFieldUpdateOperationsInput
-  purchaseOrderId: StringFieldUpdateOperationsInput
-  waybillUrl: NullableStringFieldUpdateOperationsInput
-  receivedAt: DateTimeFieldUpdateOperationsInput
-  store: StoreUpdateOneRequiredWithoutReceiptsNestedInput
-  receivedBy: UserUpdateOneRequiredWithoutStockReceiptBatchReceivedBysNestedInput
-  confirmedBy: UserUpdateOneRequiredWithoutStockReceiptBatchConfirmedBysNestedInput
-  items: StockReceiptBatchItemUpdateManyWithoutBatchNestedInput
-  PurchaseOrder: PurchaseOrderUpdateManyWithoutReceiptsNestedInput
-}
-
-input PurchaseOrderUpdateManyWithoutReceiptsNestedInput {
-  create: [PurchaseOrderCreateWithoutReceiptsInput!]
-  connectOrCreate: [PurchaseOrderCreateOrConnectWithoutReceiptsInput!]
-  upsert: [PurchaseOrderUpsertWithWhereUniqueWithoutReceiptsInput!]
-  set: [PurchaseOrderWhereUniqueInput!]
-  disconnect: [PurchaseOrderWhereUniqueInput!]
-  delete: [PurchaseOrderWhereUniqueInput!]
-  connect: [PurchaseOrderWhereUniqueInput!]
-  update: [PurchaseOrderUpdateWithWhereUniqueWithoutReceiptsInput!]
-  updateMany: [PurchaseOrderUpdateManyWithWhereWithoutReceiptsInput!]
-  deleteMany: [PurchaseOrderScalarWhereInput!]
-}
-
-input PurchaseOrderUpsertWithWhereUniqueWithoutReceiptsInput {
-  where: PurchaseOrderWhereUniqueInput!
-  update: PurchaseOrderUpdateWithoutReceiptsInput!
-  create: PurchaseOrderCreateWithoutReceiptsInput!
-}
-
-input PurchaseOrderUpdateWithoutReceiptsInput {
-  id: StringFieldUpdateOperationsInput
-  invoiceNumber: StringFieldUpdateOperationsInput
-  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
-  phase: EnumPurchasePhaseFieldUpdateOperationsInput
-  dueDate: DateTimeFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-  supplier: SupplierUpdateOneRequiredWithoutPurchaseOrdersNestedInput
-  items: PurchaseOrderItemUpdateManyWithoutPurchaseOrderNestedInput
-  payments: SupplierPaymentUpdateManyWithoutPurchaseOrderNestedInput
-}
-
-input PurchaseOrderUpdateWithWhereUniqueWithoutReceiptsInput {
-  where: PurchaseOrderWhereUniqueInput!
-  data: PurchaseOrderUpdateWithoutReceiptsInput!
-}
-
-input PurchaseOrderUpdateManyWithWhereWithoutReceiptsInput {
-  where: PurchaseOrderScalarWhereInput!
-  data: PurchaseOrderUpdateManyMutationInput!
-}
-
-input PurchaseOrderScalarWhereInput {
-  AND: [PurchaseOrderScalarWhereInput!]
-  OR: [PurchaseOrderScalarWhereInput!]
-  NOT: [PurchaseOrderScalarWhereInput!]
-  id: StringFilter
-  supplierId: StringFilter
-  invoiceNumber: StringFilter
-  status: EnumPurchaseOrderStatusFilter
-  phase: EnumPurchasePhaseFilter
-  dueDate: DateTimeFilter
-  totalAmount: FloatFilter
-  createdAt: DateTimeFilter
-  updatedAt: DateTimeFilter
-}
-
-input PurchaseOrderUpdateManyMutationInput {
-  id: StringFieldUpdateOperationsInput
-  invoiceNumber: StringFieldUpdateOperationsInput
-  status: EnumPurchaseOrderStatusFieldUpdateOperationsInput
-  phase: EnumPurchasePhaseFieldUpdateOperationsInput
-  dueDate: DateTimeFieldUpdateOperationsInput
-  totalAmount: FloatFieldUpdateOperationsInput
-  createdAt: DateTimeFieldUpdateOperationsInput
-  updatedAt: DateTimeFieldUpdateOperationsInput
-}
-
-input StockReceiptBatchUpdateToOneWithWhereWithoutPurchaseReturnsInput {
-  where: StockReceiptBatchWhereInput
-  data: StockReceiptBatchUpdateWithoutPurchaseReturnsInput!
-}
-
-input PurchaseReturnItemUpdateWithWhereUniqueWithoutReturnInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  data: PurchaseReturnItemUpdateWithoutReturnInput!
-}
-
-input PurchaseReturnItemUpdateManyWithWhereWithoutReturnInput {
-  where: PurchaseReturnItemScalarWhereInput!
-  data: PurchaseReturnItemUpdateManyMutationInput!
+  data: UserUpdateWithoutPurchaseReturnInitiatorsInput!
 }
 
 input PurchaseReturnUpdateWithWhereUniqueWithoutApprovedByInput {
@@ -21474,39 +21841,64 @@ input PurchaseReturnUpdateManyWithWhereWithoutApprovedByInput {
   data: PurchaseReturnUpdateManyMutationInput!
 }
 
-input UserUpdateToOneWithWhereWithoutPurchaseReturnInitiatorsInput {
+input UserUpdateToOneWithWhereWithoutResellerQuotationInput {
   where: UserWhereInput
-  data: UserUpdateWithoutPurchaseReturnInitiatorsInput!
+  data: UserUpdateWithoutResellerQuotationInput!
 }
 
-input PurchaseReturnUpdateToOneWithWhereWithoutItemsInput {
-  where: PurchaseReturnWhereInput
-  data: PurchaseReturnUpdateWithoutItemsInput!
+input QuotationUpdateWithWhereUniqueWithoutStoreInput {
+  where: QuotationWhereUniqueInput!
+  data: QuotationUpdateWithoutStoreInput!
 }
 
-input PurchaseReturnItemUpdateWithWhereUniqueWithoutProductVariantInput {
-  where: PurchaseReturnItemWhereUniqueInput!
-  data: PurchaseReturnItemUpdateWithoutProductVariantInput!
+input QuotationUpdateManyWithWhereWithoutStoreInput {
+  where: QuotationScalarWhereInput!
+  data: QuotationUpdateManyMutationInput!
 }
 
-input PurchaseReturnItemUpdateManyWithWhereWithoutProductVariantInput {
-  where: PurchaseReturnItemScalarWhereInput!
-  data: PurchaseReturnItemUpdateManyMutationInput!
+input StoreUpdateToOneWithWhereWithoutSalesReturnsInput {
+  where: StoreWhereInput
+  data: StoreUpdateWithoutSalesReturnsInput!
 }
 
-input ProductVariantUpdateToOneWithWhereWithoutPurchaseOrderItemInput {
-  where: ProductVariantWhereInput
-  data: ProductVariantUpdateWithoutPurchaseOrderItemInput!
+input SalesReturnUpdateWithWhereUniqueWithoutConsumerSaleInput {
+  where: SalesReturnWhereUniqueInput!
+  data: SalesReturnUpdateWithoutConsumerSaleInput!
 }
 
-input PurchaseOrderItemUpdateWithWhereUniqueWithoutPurchaseOrderInput {
-  where: PurchaseOrderItemWhereUniqueInput!
-  data: PurchaseOrderItemUpdateWithoutPurchaseOrderInput!
+input SalesReturnUpdateManyWithWhereWithoutConsumerSaleInput {
+  where: SalesReturnScalarWhereInput!
+  data: SalesReturnUpdateManyMutationInput!
 }
 
-input PurchaseOrderItemUpdateManyWithWhereWithoutPurchaseOrderInput {
-  where: PurchaseOrderItemScalarWhereInput!
-  data: PurchaseOrderItemUpdateManyMutationInput!
+input ConsumerSaleUpdateWithWhereUniqueWithoutCustomerProfileInput {
+  where: ConsumerSaleWhereUniqueInput!
+  data: ConsumerSaleUpdateWithoutCustomerProfileInput!
+}
+
+input ConsumerSaleUpdateManyWithWhereWithoutCustomerProfileInput {
+  where: ConsumerSaleScalarWhereInput!
+  data: ConsumerSaleUpdateManyMutationInput!
+}
+
+input CustomerProfileUpdateToOneWithWhereWithoutReferralsInput {
+  where: CustomerProfileWhereInput
+  data: CustomerProfileUpdateWithoutReferralsInput!
+}
+
+input CustomerProfileUpdateWithWhereUniqueWithoutPreferredStoreInput {
+  where: CustomerProfileWhereUniqueInput!
+  data: CustomerProfileUpdateWithoutPreferredStoreInput!
+}
+
+input CustomerProfileUpdateManyWithWhereWithoutPreferredStoreInput {
+  where: CustomerProfileScalarWhereInput!
+  data: CustomerProfileUpdateManyMutationInput!
+}
+
+input StoreUpdateToOneWithWhereWithoutPurchaseOrdersInput {
+  where: StoreWhereInput
+  data: StoreUpdateWithoutPurchaseOrdersInput!
 }
 
 input PurchaseOrderUpdateWithWhereUniqueWithoutSupplierInput {
@@ -21982,6 +22374,7 @@ input ProductVariantUpdateWithoutTransferItemsInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input ProductVariantUpdateToOneWithWhereWithoutTransferItemsInput {
@@ -22675,6 +23068,7 @@ input ProductVariantCreateInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemCreateNestedManyWithoutProductVariantInput
   SupplierCatalog: SupplierCatalogCreateNestedManyWithoutProductVariantInput
   SupplierQuoteItem: SupplierQuoteItemCreateNestedManyWithoutProductVariantInput
+  ProductVariantTierPrice: ProductVariantTierPriceCreateNestedManyWithoutVariantInput
 }
 
 input ProductVariantCreateManyInput {
@@ -22715,6 +23109,7 @@ input ProductVariantUpdateInput {
   PurchaseRequisitionItem: PurchaseRequisitionItemUpdateManyWithoutProductVariantNestedInput
   SupplierCatalog: SupplierCatalogUpdateManyWithoutProductVariantNestedInput
   SupplierQuoteItem: SupplierQuoteItemUpdateManyWithoutProductVariantNestedInput
+  ProductVariantTierPrice: ProductVariantTierPriceUpdateManyWithoutVariantNestedInput
 }
 
 input UpsertVariantSupplierCatalogInput {
@@ -22723,6 +23118,12 @@ input UpsertVariantSupplierCatalogInput {
   defaultCost: Float!
   leadTimeDays: Float
   isPreferred: Boolean
+}
+
+input UpsertVariantTierPriceInput {
+  productVariantId: String!
+  tier: UserTier!
+  price: Float!
 }
 
 input CreateUserInput {
@@ -23081,6 +23482,7 @@ input StoreCreateInput {
   CustomerProfile: CustomerProfileCreateNestedManyWithoutPreferredStoreInput
   Quotation: QuotationCreateNestedManyWithoutStoreInput
   PurchaseRequisition: PurchaseRequisitionCreateNestedManyWithoutStoreInput
+  purchaseOrders: PurchaseOrderCreateNestedManyWithoutStoreInput
 }
 
 input StoreCreateManyInput {
@@ -23113,6 +23515,7 @@ input StoreUpdateInput {
   CustomerProfile: CustomerProfileUpdateManyWithoutPreferredStoreNestedInput
   Quotation: QuotationUpdateManyWithoutStoreNestedInput
   PurchaseRequisition: PurchaseRequisitionUpdateManyWithoutStoreNestedInput
+  purchaseOrders: PurchaseOrderUpdateManyWithoutStoreNestedInput
 }
 
 input UserCreateInput {


### PR DESCRIPTION
…storeId to PurchaseOrder with backfill and wire store-scoped queries

- Add VariantTierPrice type and update tierPricesForVariant return type
- Seed sample tier prices for GOLD-24-EDP-100ML
- Add nullable storeId to PurchaseOrder + relation on Store
- Update PO creation to set storeId from requisition
- Update overdue PO query to prefer storeId with receipt fallback
- Migration includes SQL backfill for historical POs
- Add backfill script prisma/scripts/backfill-po-store-id.ts
- Regenerate Prisma client and GraphQL types